### PR TITLE
Replace hashValue with Hashable.hash(into:)

### DIFF
--- a/Sources/PeripheryKit/Indexer/Declaration.swift
+++ b/Sources/PeripheryKit/Indexer/Declaration.swift
@@ -283,8 +283,9 @@ public class Declaration: Entity, CustomStringConvertible {
 }
 
 extension Declaration: Hashable {
-    public var hashValue: Int {
-        return kind.rawValue.hashValue ^ usr.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(kind)
+        hasher.combine(usr)
     }
 }
 

--- a/Sources/PeripheryKit/Indexer/Reference.swift
+++ b/Sources/PeripheryKit/Indexer/Reference.swift
@@ -89,14 +89,15 @@ class Reference: Entity {
 }
 
 extension Reference: Hashable {
-    var hashValue: Int {
-        var value = kind.rawValue.hashValue ^ usr.hashValue ^ location.hashValue ^ isRelated.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(kind)
+        hasher.combine(usr)
+        hasher.combine(location)
+        hasher.combine(isRelated)
 
         if let receiverUsr = receiverUsr {
-            value = value ^ receiverUsr.hashValue
+            hasher.combine(receiverUsr)
         }
-
-        return value
     }
 }
 

--- a/Sources/PeripheryKit/SourceFile.swift
+++ b/Sources/PeripheryKit/SourceFile.swift
@@ -10,8 +10,8 @@ public struct SourceFile {
 }
 
 extension SourceFile: Hashable {
-    public var hashValue: Int {
-        return path.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(path)
     }
 }
 

--- a/Sources/PeripheryKit/SourceLocation.swift
+++ b/Sources/PeripheryKit/SourceLocation.swift
@@ -46,8 +46,8 @@ extension SourceLocation: Equatable {
 }
 
 extension SourceLocation: Hashable {
-    public var hashValue: Int {
-        return description.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(description)
     }
 }
 

--- a/Sources/PeripheryKit/Syntax/UnusedParamParser.swift
+++ b/Sources/PeripheryKit/Syntax/UnusedParamParser.swift
@@ -29,6 +29,10 @@ class Parameter: Item, Hashable {
         return lhs.location == rhs.location
     }
 
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(location)
+    }
+
     let firstName: String?
     let secondName: String?
     let metatype: String?
@@ -47,10 +51,6 @@ class Parameter: Item, Hashable {
         let decl = Declaration(kind: .varParameter, usr: usr, location: location)
         decl.name = name
         return decl
-    }
-
-    var hashValue: Int {
-        return location.hashValue
     }
 
     init(firstName: String?, secondName: String?, metatype: String?, location: SourceLocation) {

--- a/Sources/PeripheryKit/Xcode/Project.swift
+++ b/Sources/PeripheryKit/Xcode/Project.swift
@@ -78,8 +78,8 @@ public class Project: XcodeProjectlike {
 }
 
 extension Project: Hashable {
-    public var hashValue: Int {
-        return path.absolute().string.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(path.absolute().string)
     }
 }
 

--- a/Sources/PeripheryKit/Xcode/Scheme.swift
+++ b/Sources/PeripheryKit/Xcode/Scheme.swift
@@ -43,8 +43,8 @@ public class Scheme {
 }
 
 extension Scheme: Hashable {
-    public var hashValue: Int {
-        return name.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
     }
 }
 

--- a/Sources/PeripheryKit/Xcode/Target.swift
+++ b/Sources/PeripheryKit/Xcode/Target.swift
@@ -127,8 +127,8 @@ public class Target {
 }
 
 extension Target: Hashable {
-    public var hashValue: Int {
-        return target.name.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(target.name)
     }
 }
 


### PR DESCRIPTION
Hey there! Really exciting seeing this project come to open source. 🏆 

Wanted to push a tiny PR to switch from `hashValue` to `hash(into:)` as added in [Swift 4.2's SE-0206](https://github.com/apple/swift-evolution/blob/master/proposals/0206-hashable-enhancements.md#hash-into). 