### PR TITLE
Fix table of contents link destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   * [Enumerations](#enumerations)
   * [Objective-C](#objective-c)
   * [Aggressive Mode](#aggressive-mode)
-  * [Global Equatable Operators](#Gglobal-equatable-operators)
+  * [Global Equatable Operators](#global-equatable-operators)
 
 ## Installation
 


### PR DESCRIPTION
Previously the "Global Equatable Operators" link had an extra "G" in it, causing the link to do nothing.