### PR TITLE
Suport Swift5.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-syntax",
         "state": {
           "branch": null,
-          "revision": "43aa4a19b8105a803d8149ad2a86aa53a77efef3",
-          "version": "0.50000.0"
+          "revision": "3e3eb191fcdbecc6031522660c4ed6ce25282c25",
+          "version": "0.50100.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/jpsim/SourceKitten",
         "state": {
           "branch": null,
-          "revision": "fd9091759201473aa234c22322a3939615aef59a",
-          "version": "0.23.2"
+          "revision": "77a4dbbb477a8110eb8765e3c44c70fb4929098f",
+          "version": "0.29.0"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
         "state": {
           "branch": null,
-          "revision": "f43166a8e18fdd0857f29e303b1bb79a5428bca0",
-          "version": "4.9.0"
+          "revision": "a4931e5c3bafbedeb1601d3bb76bbe835c6d475a",
+          "version": "5.0.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ileitch/Commandant", .branch("boolean-option")),
-        .package(url: "https://github.com/jpsim/SourceKitten", from: "0.20.0"),
+        .package(url: "https://github.com/jpsim/SourceKitten", from: "0.29.0"),
         .package(url: "https://github.com/tuist/xcodeproj", from: "6.0.0"),
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift", from: "0.1.0"),
         .package(url: "https://github.com/kylef/PathKit", from: "0.9.2"),

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .package(url: "https://github.com/tuist/xcodeproj", from: "6.0.0"),
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift", from: "0.1.0"),
         .package(url: "https://github.com/kylef/PathKit", from: "0.9.2"),
-        .package(url: "https://github.com/apple/swift-syntax", from: "0.50000.0")
+        .package(url: "https://github.com/apple/swift-syntax", from: "0.50100.0")
     ],
     targets: [
         .target(

--- a/Sources/PeripheryKit/Indexer/SwiftIndexer.swift
+++ b/Sources/PeripheryKit/Indexer/SwiftIndexer.swift
@@ -85,11 +85,8 @@ final class SwiftIndexer: TypeIndexer {
     }
 
     private func parseUnusedParams(_ sourceFile: SourceFile, _ sourceKit: SourceKit) throws {
-        let syntaxTree = try sourceKit.editorOpenSyntaxTree(sourceFile)
-        guard let syntaxTreeJson = syntaxTree[SourceKit.Key.serializedSyntaxTree.rawValue] as? String else { return }
-
         let analyzer = UnusedParameterAnalyzer()
-        let params = try analyzer.analyze(file: sourceFile.path, json: syntaxTreeJson, parseProtocols: true)
+        let params = try analyzer.analyze(file: sourceFile.path, parseProtocols: true)
 
         for param in params {
             guard let functionDecl = try functionDecl(for: param, sourceKit) else { continue }

--- a/Sources/PeripheryKit/Syntax/UnusedParamParser.swift
+++ b/Sources/PeripheryKit/Syntax/UnusedParamParser.swift
@@ -110,22 +110,7 @@ final class UnusedParamParser {
     }
 
     func parse() throws -> [Function] {
-        let sourceKit = SourceKit(arguments: [])
-        let syntaxTreeResponse = try sourceKit.syntaxTree(file: file)
-        let key = SourceKit.Key.serializedSyntaxTree.rawValue
-
-        guard let syntaxTreeJson = syntaxTreeResponse[key] as? String
-            else { return [] }
-
-        return try parse(syntaxTreeJson: syntaxTreeJson)
-    }
-
-    func parse(syntaxTreeJson: String) throws -> [Function] {
-        guard let syntaxTreeData = syntaxTreeJson.data(using: .utf8)
-            else { return [] }
-
-        let deserializer = SyntaxTreeDeserializer()
-        let syntax = try deserializer.deserialize(syntaxTreeData, serializationFormat: .json)
+        let syntax = try SyntaxTreeParser.parse(file.url)
         return parse(item: syntax, collecting: Function.self)
     }
 

--- a/Sources/PeripheryKit/Syntax/UnusedParamParser.swift
+++ b/Sources/PeripheryKit/Syntax/UnusedParamParser.swift
@@ -252,8 +252,7 @@ final class UnusedParamParser {
         var position = syntax.initKeyword.position
 
         if let leftBracket = syntax.genericParameterClause?.leftAngleBracket {
-            // leftBracket offset is incorrect by +1
-            position = AbsolutePosition(utf8Offset: leftBracket.position.utf8Offset - 5)
+            position = AbsolutePosition(utf8Offset: leftBracket.position.utf8Offset - 4)
         } else {
             let leftParen = syntax.parameters.leftParen
             position = AbsolutePosition(utf8Offset: leftParen.position.utf8Offset - 4)

--- a/Sources/PeripheryKit/Syntax/UnusedParameterAnalyzer.swift
+++ b/Sources/PeripheryKit/Syntax/UnusedParameterAnalyzer.swift
@@ -14,12 +14,6 @@ final class UnusedParameterAnalyzer {
         return Set(functions.flatMap { analyze(function: $0) })
     }
 
-    func analyze(file: Path, json: String, parseProtocols: Bool) throws -> Set<Parameter> {
-        let parser = UnusedParamParser(file: file, parseProtocols: parseProtocols)
-        let functions = try parser.parse(syntaxTreeJson: json)
-        return Set(functions.flatMap { analyze(function: $0) })
-    }
-
     func analyze(function: Function) -> Set<Parameter> {
         return Set(unusedParams(in: function))
     }

--- a/Sources/PeripheryKit/Xcode/SourceKit.swift
+++ b/Sources/PeripheryKit/Xcode/SourceKit.swift
@@ -17,7 +17,6 @@ final class SourceKit {
         case attribute = "key.attribute"
         case substructure = "key.substructure"
         case accessibility = "key.accessibility"
-        case serializedSyntaxTree = "key.serialized_syntax_tree"
     }
 
     static func make(buildPlan: BuildPlan, target: Target) throws -> Self {

--- a/Tests/PeripheryKitTests/RetentionTest.swift
+++ b/Tests/PeripheryKitTests/RetentionTest.swift
@@ -181,7 +181,7 @@ class RetentionTest: XCTestCase {
         analyze()
 
         // Retained because it's a method from an external declaration (in this case, Equatable)
-        XCTAssertReferenced((.functionMethodStatic, "==(_:_:)"),
+        XCTAssertReferenced((.functionOperatorInfix, "==(_:_:)"),
                             descendentOf: (.class, "FixtureClass55"))
     }
 
@@ -626,7 +626,7 @@ class RetentionTest: XCTestCase {
         XCTAssertReferenced((.extensionProtocol, "FixtureProtocol96"))
         XCTAssertReferenced((.varInstance, "usedValue"),
                             descendentOf: (.protocol, "FixtureProtocol96"))
-        XCTAssertReferenced((.functionMethodStatic, "<(_:_:)"),
+        XCTAssertReferenced((.functionOperatorInfix, "<(_:_:)"),
                             descendentOf: (.extensionProtocol, "FixtureProtocol96"))
         XCTAssertNotReferenced((.varInstance, "unusedValue"),
                                descendentOf: (.protocol, "FixtureProtocol96"))

--- a/Tests/PeripheryKitTests/Syntax/UnusedParamTest.swift
+++ b/Tests/PeripheryKitTests/Syntax/UnusedParamTest.swift
@@ -126,7 +126,7 @@ class UnusedParamTest: XCTestCase {
         let init2 = functions.last!
         XCTAssertEqual(init2.location.line!, 8)
         XCTAssertEqual(init2.location.column!, 5)
-        XCTAssertEqual(init2.location.offset!, 110)
+        XCTAssertEqual(init2.location.offset!, 111)
     }
 
     // MARK: - Known Failures

--- a/Tests/PeripheryKitTests/Xcode/XcodebuildLogParserTest.swift
+++ b/Tests/PeripheryKitTests/Xcode/XcodebuildLogParserTest.swift
@@ -49,7 +49,7 @@ class XcodebuildLogParserTest: XCTestCase {
 
         let targetArgument = arguments.first { $0.key == "-target" }
         XCTAssertNotNil(target)
-        XCTAssertEqual(targetArgument!.value, "x86_64-apple-macosx10.12")
+        XCTAssertEqual(targetArgument!.value, "x86_64-apple-macos10.12")
 
         // Check that files have been removed
         let containsFile = arguments.contains(where: { $0.key.hasSuffix(".swift") })


### PR DESCRIPTION
- Update SwiftSyntax to support Swift5.1
  - Remove byte-tree related code because it's removed from swift-syntax
  - Fix compile error for new swift-syntax