### PR TITLE
Skip to parse file list when there is not

### DIFF
--- a/Sources/PeripheryKit/Xcode/XcodebuildLogParser.swift
+++ b/Sources/PeripheryKit/Xcode/XcodebuildLogParser.swift
@@ -77,7 +77,10 @@ final class XcodebuildLogParser {
             var threadsArgument = arguments[threadsArgumentIndex]
             arguments.remove(at: threadsArgumentIndex)
             let parts = threadsArgument.value?.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true).map { String($0) } ?? []
-            files += parseFileList(parts.last)
+            // When there isn't file list after num-threads value skip parsing files
+            if parts.count > 1 {
+                files += parseFileList(parts.last)
+            }
             threadsArgument.value = parts.first
             arguments.insert(threadsArgument, at: threadsArgumentIndex)
         }


### PR DESCRIPTION
Latest Xcode doesn't pass file paths through argument bacause it uses new filelist thing https://github.com/peripheryapp/periphery/pull/61

So we need to skip to parse if there isn't files after num-threads option