### PR TITLE
Bump podspec version to 1.6.0.

### DIFF
--- a/Periphery.podspec
+++ b/Periphery.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = "Periphery"
-  spec.version          = "1.5.1"
+  spec.version          = "1.6.0"
   spec.summary          = "Eliminate Unused Swift Code."
   spec.homepage         = "https://github.com/peripheryapp/periphery"
   spec.license          = { :type => 'MIT', :file => 'LICENSE.md' }


### PR DESCRIPTION
CocoaPods is currently pointing to an old version which isn't working with Xcode 11.4 (although I haven't tested older versions, they may not be working either).

This bumps the Podspec — it would still need to be properly released to the CocoaPods repo, but at least we can use the `:git` directive with this.