### PR TITLE
Support Xcode12

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/jpsim/SourceKitten",
         "state": {
           "branch": null,
-          "revision": "77a4dbbb477a8110eb8765e3c44c70fb4929098f",
-          "version": "0.29.0"
+          "revision": "c0f960f72fa1e6151695074ffa696e4da6c45ce8",
+          "version": "0.30.1"
         }
       },
       {
@@ -141,8 +141,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "c947a306d2e80ecb2c0859047b35c73b8e1ca27f",
-          "version": "2.0.0"
+          "revision": "88caa2e6fffdbef2e91c2022d038576062042907",
+          "version": "4.0.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/apple/swift-syntax",
         "state": {
           "branch": null,
-          "revision": "0688b9cfc4c3dd234e4f55f1f056b2affc849873",
-          "version": "0.50200.0"
+          "revision": "844574d683f53d0737a9c6d706c3ef31ed2955eb",
+          "version": "0.50300.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .package(name: "XcodeProj", url: "https://github.com/tuist/xcodeproj", from: "7.9.0"),
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift", from: "1.3.0"),
         .package(url: "https://github.com/kylef/PathKit", from: "1.0.0"),
-        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax", .exact("0.50200.0")),
+        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax", .exact("0.50300.0")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.0.4")),
         .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("master")),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "PeripheryKit", targets: ["PeripheryKit"])
     ],
     dependencies: [
-        .package(url: "https://github.com/jpsim/SourceKitten", from: "0.29.0"),
+        .package(url: "https://github.com/jpsim/SourceKitten", from: "0.30.1"),
         .package(name: "XcodeProj", url: "https://github.com/tuist/xcodeproj", from: "7.9.0"),
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift", from: "1.3.0"),
         .package(url: "https://github.com/kylef/PathKit", from: "1.0.0"),

--- a/Sources/PeripheryKit/Xcode/XcodebuildLogParser.swift
+++ b/Sources/PeripheryKit/Xcode/XcodebuildLogParser.swift
@@ -51,6 +51,7 @@ final class XcodebuildLogParser {
     // MARK: - Private
 
     private func parseSwiftcInvocation(command: String) -> SwiftcInvocation {
+        let command = command.replacingOccurrences(of: "\\=", with: "=")
         let pattern = try! NSRegularExpression(pattern: " (-.+?)(?= -|$)", options: []) // swiftlint:disable:this force_try
         let matches = pattern.matches(in: command, options: [], range: NSRange(command.startIndex..., in: command))
         var arguments: [BuildArgument] = matches.map {

--- a/Tests/PeripheryKitTests/Xcode/XcodebuildLogParserTest.swift
+++ b/Tests/PeripheryKitTests/Xcode/XcodebuildLogParserTest.swift
@@ -49,7 +49,7 @@ class XcodebuildLogParserTest: XCTestCase {
 
         let targetArgument = arguments.first { $0.key == "-target" }
         XCTAssertNotNil(target)
-        try XCTAssertEqual(XCTUnwrap(targetArgument).value, "x86_64-apple-macos10.12")
+        try XCTAssertEqual(XCTUnwrap(targetArgument).value, "x86_64-apple-macos10.15")
 
         // Check that files have been removed
         let containsFile = arguments.contains(where: { $0.key.hasSuffix(".swift") })


### PR DESCRIPTION
The main change is https://github.com/peripheryapp/periphery/pull/109/commits/997d92611db6b7d121f6e6a725f2b8c9fdda63ad . 

Since Xcode12, it started to escapes `=` with `\=`, so we need to un-escape it before passing the arguments to sourcekit.

Fix https://github.com/peripheryapp/periphery/issues/107