### PR TITLE
Lowercase product type before checking if it is a test

### DIFF
--- a/Sources/XcodeSupport/XcodeTarget.swift
+++ b/Sources/XcodeSupport/XcodeTarget.swift
@@ -22,7 +22,7 @@ final class XcodeTarget {
     }
 
     var isTestTarget: Bool {
-        target.productType?.rawValue.contains("test") ?? false
+        target.productType?.rawValue.lowercased().contains("test") ?? false
     }
 
     var name: String {


### PR DESCRIPTION
It's not clear if/when this changed, but targets with a type of `unitTestBundle` would fail this check without this change.