### PR TITLE
Add Folder exclusion from report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ##### Enhancements
 
-- None.
+- Added folder exclusion from report
 
 ##### Bug Fixes
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,19 @@
 RELEASE_BUILD_FLAGS=-c release --disable-sandbox --arch x86_64 --arch arm64
-BIN_PATH=$(shell swift build $(RELEASE_BUILD_FLAGS) --show-bin-path)/periphery
+BIN_PATH=$(shell swift build $(RELEASE_BUILD_FLAGS) --show-bin-path)
+XCODE_PATH:=$(shell xcode-select -p)
 
 build_release:
 	@swift build $(RELEASE_BUILD_FLAGS)
-	@install_name_tool -add_rpath @loader_path ${BIN_PATH}
+	@install_name_tool -add_rpath @loader_path ${BIN_PATH}/periphery
 
 show_bin_path:
 	@echo ${BIN_PATH}
+
+uninstall:
+	@rm -f "/usr/local/bin/periphery"
+
+install: uninstall build_release
+	@cp $(XCODE_PATH)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/lib_InternalSwiftSyntaxParser.dylib $(BIN_PATH)
+	@install_name_tool -change @executable_path/lib_InternalSwiftSyntaxParser.dylib @executable_path/../libexec/lib_InternalSwiftSyntaxParser.dylib $(BIN_PATH)/periphery
+	@ln -s ${BIN_PATH}/periphery /usr/local/bin
+

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Both exclusion options described below accept a path glob, either absolute or re
 
 ### Excluding Results
 
-To exclude the results from certain files, pass the `--report-exclude <globs>` option to the `scan` command.
+To exclude the results from certain files, pass the `--report-exclude <globs>` option to the `scan` command. Full folders can also be excluded by passing a relative path to the directory, e.g. `Sources/Frontend/`
 
 ### Excluding Indexed Files
 

--- a/Sources/Frontend/Formatters/OutputDeclarationFilter.swift
+++ b/Sources/Frontend/Formatters/OutputDeclarationFilter.swift
@@ -1,6 +1,7 @@
 import Foundation
-import Shared
 import PeripheryKit
+import Shared
+import SystemPackage
 
 final class OutputDeclarationFilter: Injectable {
     static func make() -> Self {
@@ -17,13 +18,25 @@ final class OutputDeclarationFilter: Injectable {
 
     func filter(_ declarations: [ScanResult]) -> [ScanResult] {
         let excludedSourceFiles = configuration.reportExcludeSourceFiles
+        var visited: [FilePath: Bool] = [:]
 
         excludedSourceFiles.forEach {
             logger.debug("[report:exclude] \($0.string)")
         }
+        
+        return declarations.filter { result in
 
-        return declarations.filter {
-            !excludedSourceFiles.contains($0.declaration.location.file.path)
+            let path = result.declaration.location.file.path
+
+            if let previous = visited[path] {
+
+                return previous
+            }
+
+            let contains = !excludedSourceFiles.contains { path.starts(with: $0) }
+            visited[path] = contains
+
+            return contains
         }
     }
 }


### PR DESCRIPTION
:wave: Heyo

I've been using Periphery and noticed that, although we can exclude single files with the `--report-exclude` parameter, it's not possible to exclude folders.

I've implemented it for myself and thought that it might be of interest merging this upstream.

Since I had periphery already running before, I could compare both runs and no increment in runtime was noticed, nor current support for excluding files changed.

It still does not support recursive globs though (as mentioned in docs).

Also, while trying to develop for myself, I've also added rules to the Makefile that allow for testing the developing version of periphery locally (couldn't test the relative path while running in another project, using `swift run periphery`). I believe these could be useful for the development workflow.

Didn't open an issue or discussion prior since the code was already done 😅 

Thanks for putting an effort into this project 👍🏻

TL;DR
* Added a minor change to support excluding folders from the report
* Added 2 Makefile rules to allow testing periphery locally
* Added a minor change to the README explaining this
* Added an entry to the CHANGELOG