### PR TITLE
Fix a typo

### DIFF
--- a/Sources/Shared/Injector.swift
+++ b/Sources/Shared/Injector.swift
@@ -24,7 +24,7 @@ private final class Injector {
             singletons[identifier] = singleton
         }
 
-        if singletonQueue.getSpecific(key: singletonQueueSpecificKey) == nil {
+        if DispatchQueue.getSpecific(key: singletonQueueSpecificKey) == nil {
             singletonQueue.sync(execute: block)
         } else {
             block()


### PR DESCRIPTION
singletonQueue.getSpecific(key: singletonQueueSpecificKey) will always be nonnull. call its static method to get singletonQueueSpecificKey from current context.