### PR TITLE
fix: update dependencies for xcode 13 support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -12,11 +12,11 @@
       },
       {
         "package": "PathKit",
-        "repositoryURL": "https://github.com/kylef/PathKit",
+        "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
           "branch": null,
-          "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
-          "version": "1.0.0"
+          "revision": "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+          "version": "1.0.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
           "branch": null,
-          "revision": "f79d4ecbf8bc4e1579fbd86c3e1d652fb6876c53",
-          "version": "0.9.2"
+          "revision": "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+          "version": "0.10.1"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "fd4c3b68a0c04c4c6cda27f0213c3703d50080e8",
-          "version": "1.0.0"
+          "revision": "d2930e8fcf9c33162b9fcc1d522bc975e2d4179b",
+          "version": "1.0.1"
         }
       },
       {
@@ -51,7 +51,7 @@
         "repositoryURL": "https://github.com/apple/swift-syntax",
         "state": {
           "branch": "release/5.5",
-          "revision": "cf40be70deaf4ce7d44eb1a7e14299c391e2363f",
+          "revision": "2ca29758ed04c0a209221db59f922d4faf539f03",
           "version": null
         }
       },
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/tuist/xcodeproj",
         "state": {
           "branch": null,
-          "revision": "8e83191dba8bcbfc0be4d7c48bf1e02e7fedc88c",
-          "version": "8.2.0"
+          "revision": "446f3a0db73e141c7f57e26fcdb043096b1db52c",
+          "version": "8.3.1"
         }
       },
       {


### PR DESCRIPTION
This change is the result of running `swift package update`. It includes two important updates:

1. [Xcode 13 fix in PathKit](https://github.com/kylef/PathKit/commit/c7dace24a786af674fb22035c1f52585ac3bd734)
2. [Xcode 13 fix in XcodeProj](https://github.com/tuist/XcodeProj/commit/acfe03a35cfc438ef9adb2e1b187b41926bfab78)

Currently (on 2.8.1), an error occurs when trying to run periphery with Swift 5.5 (Xcode 13):

```
[16/25] Compiling PathKit PathKit.swift
[...]/PathKit/Sources/PathKit.swift:583:12: error: value of optional type 'UnsafeMutablePointer<CChar>?' (aka 'Optional<UnsafeMutablePointer<Int8>>') must be unwrapped to a value of type 'UnsafeMutablePointer<CChar>' (aka 'UnsafeMutablePointer<Int8>')
      free(cPattern)
           ^
[...]/PathKit/Sources/PathKit.swift:583:12: note: coalesce using '??' to provide a default when the optional value contains 'nil'
      free(cPattern)
           ^
                    ?? <#default value#>
[...]/PathKit/Sources/PathKit.swift:583:12: note: force-unwrap using '!' to abort execution if the optional value contains 'nil'
      free(cPattern)
           ^
                   !
```

This is fixed with the changes in this PR. I tested this by building the Periphery executable from this branch and running `periphery scan` on my project.

---

Consider removing `Package.resolved` from source control to avoid this problem in the future.