### PR TITLE
Consider DEVELOPER_DIR environment variable

### DIFF
--- a/Sources/Shared/Shell.swift
+++ b/Sources/Shared/Shell.swift
@@ -46,15 +46,17 @@ final class ReadableStream {
 
 open class Shell: Singleton {
     public static func make() -> Self {
-        return self.init(logger: inject())
+        return self.init(environment: ProcessInfo.processInfo.environment, logger: inject())
     }
 
     private var tasks: Set<Process> = []
     private var tasksQueue = DispatchQueue(label: "Shell.tasksQueue")
 
+    private let environment: [String: String]
     private let logger: ContextualLogger
 
-    required public init(logger: Logger) {
+    required public init(environment: [String: String], logger: Logger) {
+        self.environment = environment
         self.logger = logger.contextualized(with: "shell")
     }
 
@@ -63,9 +65,9 @@ open class Shell: Singleton {
     }
 
     private lazy var pristineEnvironment: [String: String] = {
-        let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/bash"
+        let shell = environment["SHELL"] ?? "/bin/bash"
         guard let pristineEnv = try? exec([shell, "-lc", "env"], stderr: false, environment: [:]) else {
-            return ProcessInfo.processInfo.environment
+            return environment
         }
 
         var newEnv = pristineEnv.trimmed
@@ -79,7 +81,7 @@ open class Shell: Singleton {
 
         let preservedKeys = ["PATH"]
         preservedKeys.forEach { key in
-            if let value = ProcessInfo.processInfo.environment[key] {
+            if let value = environment[key] {
                 newEnv[key] = value
             }
         }

--- a/Sources/Shared/Shell.swift
+++ b/Sources/Shared/Shell.swift
@@ -64,7 +64,7 @@ open class Shell: Singleton {
         tasksQueue.sync { tasks.forEach { $0.interrupt() } }
     }
 
-    private lazy var pristineEnvironment: [String: String] = {
+    lazy var pristineEnvironment: [String: String] = {
         let shell = environment["SHELL"] ?? "/bin/bash"
         guard let pristineEnv = try? exec([shell, "-lc", "env"], stderr: false, environment: [:]) else {
             return environment

--- a/Sources/Shared/Shell.swift
+++ b/Sources/Shared/Shell.swift
@@ -79,7 +79,7 @@ open class Shell: Singleton {
                 result[pair.0] = pair.1
             }
 
-        let preservedKeys = ["PATH"]
+        let preservedKeys = ["PATH", "DEVELOPER_DIR"]
         preservedKeys.forEach { key in
             if let value = environment[key] {
                 newEnv[key] = value

--- a/Tests/PeripheryTests/ShellTest.swift
+++ b/Tests/PeripheryTests/ShellTest.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import Shared
+
+final class ShellTest: XCTestCase {
+    func testPristineEnvironmentWithPreservedVariables() {
+        let path = "/path/to/bin"
+        let developerDir = "/path/to/Xcode.app/Contents/Developer"
+        let environment = [
+            "PATH": path,
+            "DEVELOPER_DIR": developerDir
+        ]
+        let shell = Shell(environment: environment, logger: .make())
+        XCTAssertEqual(shell.pristineEnvironment["PATH"], path)
+        XCTAssertEqual(shell.pristineEnvironment["DEVELOPER_DIR"], developerDir)
+    }
+}


### PR DESCRIPTION
Fixes #416 

## What I did

1. Added private property `Shell.environment` to avoid using `ProcessInfo.processInfo.environment` directly
2. Added a test case to check if `$PATH` `$DEVELOPER_DIR` are preserved in `Shell.pristineEnvironment` and confirmed it failed
3. Added `$DEVELOPER_DIR` to preserved keys and confirmed the test case passed