### PR TITLE
Wait until declaration hierarchy is fully established before associating latent references. Closes #441

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ##### Bug Fixes
 
-- None.
+- Fix false positive when protocols requirements are satisfied in another file from the one that declares the conformance.
 
 ## 2.8.3 (2021-11-29)
 

--- a/Sources/PeripheryKit/Indexer/Declaration.swift
+++ b/Sources/PeripheryKit/Indexer/Declaration.swift
@@ -266,7 +266,11 @@ extension Declaration: CustomStringConvertible {
 
 extension Declaration: Comparable {
     public static func < (lhs: Declaration, rhs: Declaration) -> Bool {
-        lhs.location < rhs.location
+        if lhs.location == rhs.location {
+            return lhs.usrs.sorted().joined() < rhs.usrs.sorted().joined()
+        }
+
+        return lhs.location < rhs.location
     }
 }
 

--- a/Sources/Shared/Logger.swift
+++ b/Sources/Shared/Logger.swift
@@ -104,6 +104,10 @@ public struct ContextualLogger {
     let logger: Logger
     let context: String
 
+    public func contextualized(with innerContext: String) -> ContextualLogger {
+        logger.contextualized(with: "\(context):\(innerContext)")
+    }
+
     public func debug(_ text: String) {
         logger.debug("[\(context)] \(text)")
     }


### PR DESCRIPTION
Protocol requirements may be satisfied in another file from the one that declares the conformance. When this is the case, the ordering of indexing determines whether the related references are associated with the correct declaration or not.

Example:

file_a.swift:
```
protocol VaultCompatible {
    static func decode(source: Any?) -> Self?
    func encode() -> Any
}

extension RawRepresentable where Self: VaultCompatible, RawValue == String {
     static func decode(source: Any?) -> Self? {
         if let value = source as? RawValue {
             return .init(rawValue: value)
         }
         return nil
     }

     func encode() -> Any {
         return rawValue
     }
}
```

file_b.swift:
```
enum SomeEnum: String, CaseIterable {
    case first
    case second
}

extension SomeEnum: VaultCompatible {}
```