### PR TITLE
Make comment commands retain redundant protocols. Closes #442

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix false positive when protocols requirements are satisfied in another file from the one that declares the conformance.
 - Fix redundant public accessibility analysis of enum associated value types.
 - Fix redundant public accessibility analysis of aliased types.
+- Comment commands can now retain redundant protocols.
 
 ## 2.8.3 (2021-11-29)
 

--- a/Sources/PeripheryKit/Analyzer/Visitors/AssignOnlyPropertyReferenceEliminator.swift
+++ b/Sources/PeripheryKit/Analyzer/Visitors/AssignOnlyPropertyReferenceEliminator.swift
@@ -31,6 +31,9 @@ final class AssignOnlyPropertyReferenceEliminator: SourceGraphVisitor {
                     !property.isComplexProperty
                 else { continue }
 
+                // Ensure the property hasn't been been explicitly retained, e.g by a comment command.
+                guard !graph.isRetained(property) else { continue }
+
                 // A protocol property can technically be assigned and never used when the protocol is used as an existential
                 // type, however communicating that succinctly would be very tricky, and most likely just lead to confusion.
                 // Here we filter out protocol properties and thus restrict this analysis only to concrete properties.

--- a/Sources/PeripheryKit/Analyzer/Visitors/RedundantProtocolMarker.swift
+++ b/Sources/PeripheryKit/Analyzer/Visitors/RedundantProtocolMarker.swift
@@ -17,8 +17,11 @@ final class RedundantProtocolMarker: SourceGraphVisitor {
         let protocolDecls = graph.declarations(ofKind: .protocol)
 
         for protocolDecl in protocolDecls {
+            // Ensure the protocol hasn't been been explicitly retained, e.g by a comment command.
+            guard !graph.isRetained(protocolDecl) else { continue }
+
             // Ensure the protocol doesn't inherit an external protocol.
-            // The foreign protool may be used only by external code which is not visibile to us.
+            // The foreign protocol may be used only by external code which is not visible to us.
             // E.g a protocol may inherit Comparable and implement the operator '<', however we have no way to see
             // that '<' is used when calling sort().
             let inheritsForeignProtocol = graph

--- a/Sources/PeripheryKit/Indexer/SourceGraph.swift
+++ b/Sources/PeripheryKit/Indexer/SourceGraph.swift
@@ -29,6 +29,10 @@ public final class SourceGraph {
         allDeclarations.subtracting(reachableDeclarations)
     }
 
+    public var assignOnlyProperties: Set<Declaration> {
+        return potentialAssignOnlyProperties.intersection(unreachableDeclarations)
+    }
+
     public init() {
         mutationQueue = DispatchQueue(label: "SourceGraph.mutationQueue")
     }

--- a/Sources/PeripheryKit/Indexer/SwiftIndexer.swift
+++ b/Sources/PeripheryKit/Indexer/SwiftIndexer.swift
@@ -406,7 +406,7 @@ public final class SwiftIndexer {
 
         private func identifyUnusedParameters(using syntaxVisitor: MultiplexingSyntaxVisitor) {
             let functionDecls = declarations.filter { $0.kind.isFunctionKind }
-            let functionDelcsByLocation = functionDecls.filter { $0.kind.isFunctionKind }.map { ($0.location, $0) }.reduce(into: [SourceLocation: Declaration]()) { $0[$1.0] = $1.1 }
+            let functionDeclsByLocation = functionDecls.filter { $0.kind.isFunctionKind }.map { ($0.location, $0) }.reduce(into: [SourceLocation: Declaration]()) { $0[$1.0] = $1.1 }
 
             let analyzer = UnusedParameterAnalyzer()
             let paramsByFunction = analyzer.analyze(
@@ -416,7 +416,7 @@ public final class SwiftIndexer {
                 parseProtocols: true)
 
             for (function, params) in paramsByFunction {
-                guard let functionDecl = functionDelcsByLocation[function.location] else {
+                guard let functionDecl = functionDeclsByLocation[function.location] else {
                     // The declaration may not exist if the code was not compiled due to build conditions, e.g #if.
                     logger.debug("Failed to associate indexed function for parameter function '\(function.name)' at \(function.location).")
                     continue

--- a/Sources/PeripheryKit/ScanResultBuilder.swift
+++ b/Sources/PeripheryKit/ScanResultBuilder.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public struct ScanResultBuilder {
     public static func build(for graph: SourceGraph) -> [ScanResult] {
-        let assignOnlyProperties = graph.potentialAssignOnlyProperties.intersection(graph.unreachableDeclarations)
+        let assignOnlyProperties = graph.assignOnlyProperties
         let removableDeclarations = graph.unreachableDeclarations.subtracting(assignOnlyProperties)
         let redundantProtocols = graph.redundantProtocols.filter { !removableDeclarations.contains($0.0) }
         let redundantPublicAccessibility = graph.redundantPublicAccessibility.filter { !removableDeclarations.contains($0.0) }

--- a/Tests/Fixtures/RetentionFixtures/testIgnoreComments.swift
+++ b/Tests/Fixtures/RetentionFixtures/testIgnoreComments.swift
@@ -22,7 +22,7 @@ public class Fixture114 {
 }
 
 extension Fixture114: Fixture114Protocol {
-    // param is ignored becuse the protocol ignores it.
+    // param is ignored because the protocol ignores it.
     public func protocolFunc(param: String) {}
 }
 
@@ -38,4 +38,17 @@ public class FixtureClass116 {
 
     // periphery:ignore
     let multiBindingPropertyA = 0, multiBindingPropertyB = 0
+
+    // periphery:ignore
+    var assignOnlyProperty = 0
+
+    public func retain() {
+        assignOnlyProperty = 1
+    }
 }
+
+// periphery:ignore
+// redundant protocol
+public protocol Fixture205Protocol {}
+// periphery:ignore
+public class Fixture205: Fixture205Protocol {}

--- a/Tests/Fixtures/RetentionFixtures/testSimplePropertyAssignedButNeverRead.swift
+++ b/Tests/Fixtures/RetentionFixtures/testSimplePropertyAssignedButNeverRead.swift
@@ -22,6 +22,8 @@ public class FixtureClass70 {
         }
     }
     var readVar: String
+    // periphery:ignore
+    var ignoredSimpleUnreadVar: String
 
     init() {
         simpleUnreadVar = "Hello"
@@ -30,6 +32,7 @@ public class FixtureClass70 {
         simpleUnreadVarAssignedMultiple = "2"
         complexUnreadVar1 = "Hello"
         readVar = "Hello"
+        ignoredSimpleUnreadVar = "Hello"
         FixtureClass70.simpleStaticUnreadVar = "Hello"
     }
 
@@ -38,6 +41,6 @@ public class FixtureClass70 {
         simpleUnreadVar = "World"
         complexUnreadVar1 = "Hello"
         complexUnreadVar2 = "Hello"
-        print(readVar.count)
+        print(readVar)
     }
 }

--- a/Tests/PeripheryTests/RetentionTest.swift
+++ b/Tests/PeripheryTests/RetentionTest.swift
@@ -867,7 +867,12 @@ final class RetentionTest: SourceGraphTestCase {
                 self.assertReferenced(.varInstance("tuplePropertyB"))
                 self.assertReferenced(.varInstance("multiBindingPropertyA"))
                 self.assertReferenced(.varInstance("multiBindingPropertyB"))
+                self.assertReferenced(.varInstance("assignOnlyProperty"))
+                self.assertNotAssignOnlyProperty(.varInstance("assignOnlyProperty"))
             }
+            assertReferenced(.class("Fixture205"))
+            assertReferenced(.protocol("Fixture205Protocol"))
+            assertNotRedundantProtocol("Fixture205Protocol")
         }
     }
 
@@ -977,15 +982,33 @@ final class RetentionTest: SourceGraphTestCase {
     // MARK: - Assign-only properties
 
     func testSimplePropertyAssignedButNeverRead() {
+        configuration.retainAssignOnlyProperties = false
+
         analyze(retainPublic: true) {
             assertReferenced(.class("FixtureClass70")) {
                 self.assertNotReferenced(.varInstance("simpleUnreadVar"))
+                self.assertAssignOnlyProperty(.varInstance("simpleUnreadVar"))
+
                 self.assertNotReferenced(.varInstance("simpleUnreadShadowedVar"))
+                self.assertAssignOnlyProperty(.varInstance("simpleUnreadShadowedVar"))
+
                 self.assertNotReferenced(.varInstance("simpleUnreadVarAssignedMultiple"))
+                self.assertAssignOnlyProperty(.varInstance("simpleUnreadVarAssignedMultiple"))
+
                 self.assertNotReferenced(.varStatic("simpleStaticUnreadVar"))
+                self.assertAssignOnlyProperty(.varStatic("simpleStaticUnreadVar"))
+
                 self.assertReferenced(.varInstance("complexUnreadVar1"))
+                self.assertNotAssignOnlyProperty(.varInstance("complexUnreadVar1"))
+
                 self.assertReferenced(.varInstance("complexUnreadVar2"))
+                self.assertNotAssignOnlyProperty(.varInstance("complexUnreadVar2"))
+
                 self.assertReferenced(.varInstance("readVar"))
+                self.assertNotAssignOnlyProperty(.varInstance("readVar"))
+
+                self.assertReferenced(.varInstance("ignoredSimpleUnreadVar"))
+                self.assertNotAssignOnlyProperty(.varInstance("ignoredSimpleUnreadVar"))
             }
         }
 
@@ -994,12 +1017,28 @@ final class RetentionTest: SourceGraphTestCase {
         analyze(retainPublic: true) {
             assertReferenced(.class("FixtureClass70")) {
                 self.assertReferenced(.varInstance("simpleUnreadVar"))
+                self.assertNotAssignOnlyProperty(.varInstance("simpleUnreadVar"))
+
                 self.assertReferenced(.varInstance("simpleUnreadShadowedVar"))
+                self.assertNotAssignOnlyProperty(.varInstance("simpleUnreadShadowedVar"))
+
                 self.assertReferenced(.varInstance("simpleUnreadVarAssignedMultiple"))
+                self.assertNotAssignOnlyProperty(.varInstance("simpleUnreadVarAssignedMultiple"))
+
                 self.assertReferenced(.varStatic("simpleStaticUnreadVar"))
+                self.assertNotAssignOnlyProperty(.varStatic("simpleStaticUnreadVar"))
+
                 self.assertReferenced(.varInstance("complexUnreadVar1"))
+                self.assertNotAssignOnlyProperty(.varInstance("complexUnreadVar1"))
+
                 self.assertReferenced(.varInstance("complexUnreadVar2"))
+                self.assertNotAssignOnlyProperty(.varInstance("complexUnreadVar2"))
+
                 self.assertReferenced(.varInstance("readVar"))
+                self.assertNotAssignOnlyProperty(.varInstance("readVar"))
+
+                self.assertReferenced(.varInstance("ignoredSimpleUnreadVar"))
+                self.assertNotAssignOnlyProperty(.varInstance("ignoredSimpleUnreadVar"))
             }
         }
     }

--- a/Tests/Shared/SourceGraphTestCase.swift
+++ b/Tests/Shared/SourceGraphTestCase.swift
@@ -122,6 +122,30 @@ open class SourceGraphTestCase: XCTestCase {
         }
     }
 
+    func assertAssignOnlyProperty(_ description: DeclarationDescription, scopedAssertions: (() -> Void)? = nil, file: StaticString = #file, line: UInt = #line) {
+        guard let declaration = materialize(description, file: file, line: line) else { return }
+
+        if !graph.assignOnlyProperties.contains(declaration) {
+            XCTFail("Expected property to be assign-only: \(declaration)", file: file, line: line)
+        }
+
+        scopeStack.append(.declaration(declaration))
+        scopedAssertions?()
+        scopeStack.removeLast()
+    }
+
+    func assertNotAssignOnlyProperty(_ description: DeclarationDescription, scopedAssertions: (() -> Void)? = nil, file: StaticString = #file, line: UInt = #line) {
+        guard let declaration = materialize(description, file: file, line: line) else { return }
+
+        if graph.assignOnlyProperties.contains(declaration) {
+            XCTFail("Expected property to not be assign-only: \(declaration)", file: file, line: line)
+        }
+
+        scopeStack.append(.declaration(declaration))
+        scopedAssertions?()
+        scopeStack.removeLast()
+    }
+
     func module(_ name: String, scopedAssertions: (() -> Void)? = nil) {
         scopeStack.append(.module(name))
         scopedAssertions?()


### PR DESCRIPTION
Also improves testing of retained assign-only properties.