### PR TITLE
Enable a more portable binary on macOS - Approach 1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "StaticSwiftSyntaxParser",
+        "repositoryURL": "https://gist.github.com/liamnichols/92f8fdcf2864d0fd1619a18828acafb8.git",
+        "state": {
+          "branch": "main",
+          "revision": "6e4cb9eb406d6acb5174202380d5407b132f7672",
+          "version": null
+        }
+      },
+      {
         "package": "AEXML",
         "repositoryURL": "https://github.com/tadija/AEXML",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://gist.github.com/liamnichols/92f8fdcf2864d0fd1619a18828acafb8.git",
         "state": {
           "branch": "main",
-          "revision": "6e4cb9eb406d6acb5174202380d5407b132f7672",
+          "revision": "4134efa908ee6932f62f243cd1815000e51f44c6",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -1,15 +1,36 @@
 // swift-tools-version:5.3
 import PackageDescription
 
+// Use the appropriate version of SwiftSyntax based on the current compiler
+#if compiler(>=5.5)
+let swiftSyntaxVersion: Package.Dependency.Requirement = .exact("0.50600.1")
+#elseif compiler(>=5.4)
+let swiftSyntaxVersion: Package.Dependency.Requirement = .exact("0.50400.0")
+#elseif compiler(>=5.3)
+let swiftSyntaxVersion: Package.Dependency.Requirement = .exact("0.50300.0")
+#else
+fatalError("This version of Periphery does not support Swift <= 5.2.")
+#endif
+
 var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-system", from: "1.0.0"),
     .package(url: "https://github.com/jpsim/Yams", from: "4.0.0"),
     .package(url: "https://github.com/tadija/AEXML", from: "4.0.0"),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
     .package(name: "SwiftIndexStore", url: "https://github.com/kateinoigakukun/swift-indexstore", from: "0.0.0"),
-    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax", .exact("0.50600.1")),
-    .package(name: "StaticSwiftSyntaxParser", url: "https://gist.github.com/liamnichols/92f8fdcf2864d0fd1619a18828acafb8.git", .branch("main"))
+    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax", swiftSyntaxVersion)
 ]
+
+// When on macOS, using SwiftSyntax for 5.6, also include StaticSwiftSyntaxParser to statically link internal dependencies
+#if os(macOS) && compiler(>=5.5)
+dependencies.append(
+    .package(
+        name: "StaticSwiftSyntaxParser",
+        url: "https://gist.github.com/liamnichols/92f8fdcf2864d0fd1619a18828acafb8.git",
+        .branch("main")
+    )
+)
+#endif
 
 #if os(macOS)
 dependencies.append(
@@ -39,13 +60,11 @@ var peripheryKitDependencies: [PackageDescription.Target.Dependency] = [
     .product(name: "SwiftIndexStore", package: "SwiftIndexStore")
 ]
 
-#if swift(>=5.6)
-peripheryKitDependencies.append(
-    .product(
-        name: "SwiftSyntaxParser",
-        package: "SwiftSyntax"
-    )
-)
+// Using Swift 5.5+, we need the SwiftSyntaxParser library, but on macOS specifically we also want to use the statically linked version
+#if os(macOS) && compiler(>=5.5)
+peripheryKitDependencies.append(.product(name: "StaticSwiftSyntaxParser", package: "StaticSwiftSyntaxParser"))
+#elseif compiler(>=5.5)
+peripheryKitDependencies.append(.product(name: "SwiftSyntaxParser", package: "SwiftSyntax"))
 #endif
 
 var targets: [PackageDescription.Target] = [
@@ -55,14 +74,7 @@ var targets: [PackageDescription.Target] = [
     ),
     .target(
         name: "PeripheryKit",
-        dependencies: [
-            .target(name: "Shared"),
-            .product(name: "SystemPackage", package: "swift-system"),
-            .product(name: "AEXML", package: "AEXML"),
-            .product(name: "SwiftSyntax", package: "SwiftSyntax"),
-            .product(name: "StaticSwiftSyntaxParser", package: "StaticSwiftSyntaxParser"),
-            .product(name: "SwiftIndexStore", package: "SwiftIndexStore")
-        ]
+        dependencies: peripheryKitDependencies
     ),
     .target(
         name: "Shared",

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,8 @@ var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/tadija/AEXML", from: "4.0.0"),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
     .package(name: "SwiftIndexStore", url: "https://github.com/kateinoigakukun/swift-indexstore", from: "0.0.0"),
-    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax", .exact("0.50600.1"))
+    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax", .exact("0.50600.1")),
+    .package(name: "StaticSwiftSyntaxParser", url: "https://gist.github.com/liamnichols/92f8fdcf2864d0fd1619a18828acafb8.git", .branch("main"))
 ]
 
 #if os(macOS)
@@ -59,15 +60,8 @@ var targets: [PackageDescription.Target] = [
             .product(name: "SystemPackage", package: "swift-system"),
             .product(name: "AEXML", package: "AEXML"),
             .product(name: "SwiftSyntax", package: "SwiftSyntax"),
-            .product(name: "SwiftSyntaxParser", package: "SwiftSyntax"),
-            .target(name: "lib_InternalSwiftSyntaxParser"),
+            .product(name: "StaticSwiftSyntaxParser", package: "StaticSwiftSyntaxParser"),
             .product(name: "SwiftIndexStore", package: "SwiftIndexStore")
-        ],
-        // Pass `-dead_strip_dylibs` to ignore the dynamic version of `lib_InternalSwiftSyntaxParser`
-        // that ships with SwiftSyntax because we want the static version from
-        // `StaticInternalSwiftSyntaxParser`.
-        linkerSettings: [
-            .unsafeFlags(["-Xlinker", "-dead_strip_dylibs"])
         ]
     ),
     .target(
@@ -129,11 +123,6 @@ var targets: [PackageDescription.Target] = [
             .target(name: "PeripheryKit")
         ],
         exclude: ["AccessibilityProject"]
-    ),
-    .binaryTarget(
-        name: "lib_InternalSwiftSyntaxParser",
-        url: "https://github.com/keith/StaticInternalSwiftSyntaxParser/releases/download/5.6/lib_InternalSwiftSyntaxParser.xcframework.zip",
-        checksum: "88d748f76ec45880a8250438bd68e5d6ba716c8042f520998a438db87083ae9d"
     )
 ]
 

--- a/Package.swift
+++ b/Package.swift
@@ -6,43 +6,9 @@ var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/jpsim/Yams", from: "4.0.0"),
     .package(url: "https://github.com/tadija/AEXML", from: "4.0.0"),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
-    .package(name: "SwiftIndexStore", url: "https://github.com/kateinoigakukun/swift-indexstore", from: "0.0.0")
+    .package(name: "SwiftIndexStore", url: "https://github.com/kateinoigakukun/swift-indexstore", from: "0.0.0"),
+    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax", .exact("0.50600.1"))
 ]
-#if swift(>=5.6)
-dependencies.append(
-    .package(
-        name: "SwiftSyntax",
-        url: "https://github.com/apple/swift-syntax",
-        .exact("0.50600.1")
-    )
-)
-#elseif swift(>=5.5)
-dependencies.append(
-    .package(
-        name: "SwiftSyntax",
-        url: "https://github.com/apple/swift-syntax",
-        .exact("0.50500.0")
-    )
-)
-#elseif swift(>=5.4)
-dependencies.append(
-    .package(
-        name: "SwiftSyntax",
-        url: "https://github.com/apple/swift-syntax",
-        .exact("0.50400.0")
-    )
-)
-#elseif swift(>=5.3)
-dependencies.append(
-    .package(
-        name: "SwiftSyntax",
-        url: "https://github.com/apple/swift-syntax",
-        .exact("0.50300.0")
-    )
-)
-#else
-fatalError("This version of Periphery does not support Swift <= 5.2.")
-#endif
 
 #if os(macOS)
 dependencies.append(
@@ -88,7 +54,21 @@ var targets: [PackageDescription.Target] = [
     ),
     .target(
         name: "PeripheryKit",
-        dependencies: peripheryKitDependencies
+        dependencies: [
+            .target(name: "Shared"),
+            .product(name: "SystemPackage", package: "swift-system"),
+            .product(name: "AEXML", package: "AEXML"),
+            .product(name: "SwiftSyntax", package: "SwiftSyntax"),
+            .product(name: "SwiftSyntaxParser", package: "SwiftSyntax"),
+            .target(name: "lib_InternalSwiftSyntaxParser"),
+            .product(name: "SwiftIndexStore", package: "SwiftIndexStore")
+        ],
+        // Pass `-dead_strip_dylibs` to ignore the dynamic version of `lib_InternalSwiftSyntaxParser`
+        // that ships with SwiftSyntax because we want the static version from
+        // `StaticInternalSwiftSyntaxParser`.
+        linkerSettings: [
+            .unsafeFlags(["-Xlinker", "-dead_strip_dylibs"])
+        ]
     ),
     .target(
         name: "Shared",
@@ -149,6 +129,11 @@ var targets: [PackageDescription.Target] = [
             .target(name: "PeripheryKit")
         ],
         exclude: ["AccessibilityProject"]
+    ),
+    .binaryTarget(
+        name: "lib_InternalSwiftSyntaxParser",
+        url: "https://github.com/keith/StaticInternalSwiftSyntaxParser/releases/download/5.6/lib_InternalSwiftSyntaxParser.xcframework.zip",
+        checksum: "88d748f76ec45880a8250438bd68e5d6ba716c8042f520998a438db87083ae9d"
     )
 ]
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.3
 import PackageDescription
 
 var dependencies: [Package.Dependency] = [

--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,10 @@
 // swift-tools-version:5.3
 import PackageDescription
 
-// Use the appropriate version of SwiftSyntax based on the current compiler
-#if compiler(>=5.5)
+#if os(macOS) && compiler(>=5.5) || compiler(>=5.6)
 let swiftSyntaxVersion: Package.Dependency.Requirement = .exact("0.50600.1")
+#elseif compiler(>=5.5)
+let swiftSyntaxVersion: Package.Dependency.Requirement = .exact("0.50500.0")
 #elseif compiler(>=5.4)
 let swiftSyntaxVersion: Package.Dependency.Requirement = .exact("0.50400.0")
 #elseif compiler(>=5.3)
@@ -21,7 +22,6 @@ var dependencies: [Package.Dependency] = [
     .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax", swiftSyntaxVersion)
 ]
 
-// When on macOS, using SwiftSyntax for 5.6, also include StaticSwiftSyntaxParser to statically link internal dependencies
 #if os(macOS) && compiler(>=5.5)
 dependencies.append(
     .package(
@@ -60,10 +60,9 @@ var peripheryKitDependencies: [PackageDescription.Target.Dependency] = [
     .product(name: "SwiftIndexStore", package: "SwiftIndexStore")
 ]
 
-// Using Swift 5.5+, we need the SwiftSyntaxParser library, but on macOS specifically we also want to use the statically linked version
 #if os(macOS) && compiler(>=5.5)
 peripheryKitDependencies.append(.product(name: "StaticSwiftSyntaxParser", package: "StaticSwiftSyntaxParser"))
-#elseif compiler(>=5.5)
+#elseif compiler(>=5.6)
 peripheryKitDependencies.append(.product(name: "SwiftSyntaxParser", package: "SwiftSyntax"))
 #endif
 

--- a/Sources/PeripheryKit/Syntax/MultiplexingSyntaxVisitor.swift
+++ b/Sources/PeripheryKit/Syntax/MultiplexingSyntaxVisitor.swift
@@ -1,9 +1,7 @@
 import Foundation
 import SystemPackage
 import SwiftSyntax
-#if swift(>=5.6)
 import SwiftSyntaxParser
-#endif
 
 protocol PeripherySyntaxVisitor {
     static func make(sourceLocationBuilder: SourceLocationBuilder) -> Self

--- a/Sources/PeripheryKit/Syntax/MultiplexingSyntaxVisitor.swift
+++ b/Sources/PeripheryKit/Syntax/MultiplexingSyntaxVisitor.swift
@@ -1,7 +1,9 @@
 import Foundation
 import SystemPackage
 import SwiftSyntax
+#if canImport(SwiftSyntaxParser)
 import SwiftSyntaxParser
+#endif
 
 protocol PeripherySyntaxVisitor {
     static func make(sourceLocationBuilder: SourceLocationBuilder) -> Self

--- a/Sources/PeripheryKit/Syntax/UnusedParameterParser.swift
+++ b/Sources/PeripheryKit/Syntax/UnusedParameterParser.swift
@@ -1,7 +1,9 @@
 import Foundation
 import SystemPackage
 import SwiftSyntax
+#if canImport(SwiftSyntaxParser)
 import SwiftSyntaxParser
+#endif
 
 protocol Item: AnyObject {
     var items: [Item] { get }

--- a/Sources/PeripheryKit/Syntax/UnusedParameterParser.swift
+++ b/Sources/PeripheryKit/Syntax/UnusedParameterParser.swift
@@ -1,9 +1,7 @@
 import Foundation
 import SystemPackage
 import SwiftSyntax
-#if swift(>=5.6)
 import SwiftSyntaxParser
-#endif
 
 protocol Item: AnyObject {
     var items: [Item] { get }

--- a/Tests/PeripheryTests/Syntax/TypeSyntaxInspectorTest.swift
+++ b/Tests/PeripheryTests/Syntax/TypeSyntaxInspectorTest.swift
@@ -1,7 +1,9 @@
 import Foundation
 import XCTest
 import SwiftSyntax
+#if canImport(SwiftSyntaxParser)
 import SwiftSyntaxParser
+#endif
 @testable import TestShared
 @testable import PeripheryKit
 

--- a/Tests/PeripheryTests/Syntax/TypeSyntaxInspectorTest.swift
+++ b/Tests/PeripheryTests/Syntax/TypeSyntaxInspectorTest.swift
@@ -1,9 +1,7 @@
 import Foundation
 import XCTest
 import SwiftSyntax
-#if swift(>=5.6)
 import SwiftSyntaxParser
-#endif
 @testable import TestShared
 @testable import PeripheryKit
 


### PR DESCRIPTION
# Background

- https://github.com/peripheryapp/periphery/issues/473

To make the `periphery` binary more portable on macOS, we want to have the lib_internalSwiftSyntaxParser library statically linked into the binary instead of having to link to a dylib version somewhere on the system.

# Approach 1

The main problem I'm trying to work around in these solutions is that I can't use binary targets in this Package.swift since it breaks `swift package describe` ([SR-15243](https://bugs.swift.org/browse/SR-15243) and [SR-15065](https://bugs.swift.org/browse/SR-15065)).

In this approach, I achieve that by extracting things out into a small placeholder-type package (StaticSwiftSyntaxParser) that declares the binary target and the dependency on swift-syntax's SwiftSyntaxParser library for the 5.6 version. This doesn't support 5.5, although it technically could but its just a little confusing because the SwiftSyntaxParser target was only added to swift-syntax in 5.6.

I feel like this approach is a little hackier than the second approach for a couple of reasons:

1. It would be nice for periphery to use StaticInternalSwiftSyntaxParser when compiling with Swift 5.5 too, but because the placeholder/wrapper package doesn't have a 5.5 version, I can't do that. But we can just use 0.50600.1 since its source-compatible with Swift 5.5, its just a bit more confusing when you look at Package.swift, especially because there is a discrepancy with Linux too as a result. It's even complicated to try and explain here 
2. We have to declare the StaticSwiftSyntaxParser dependency, but its not technically imported in the project which is also a bit confusing. 