### PR TITLE
Add Swift 5.6 to the matrix for Linux (and fix cache issues)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
         path: |
           .build
           Package.resolved
-        key: ${{ runner.os }}-${{ matrix.xcode }}-${{ steps.get-swift-version.outputs.version }}-${{ env.cache_version }}-spm-deps-${{ hashFiles('**/Package.swift', '**/Package.resolved') }}
+        key: ${{ runner.os }}-${{ matrix.xcode }}-${{ steps.get-swift-version.outputs.version }}-${{ env.cache_version }}-spm-deps-${{ hashFiles('Package.swift', 'Package.resolved') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.xcode }}-${{ steps.get-swift-version.outputs.version }}-${{ env.cache_version }}-spm-deps-
     - name: Resolve dependencies
@@ -87,7 +87,7 @@ jobs:
         path: |
           .build
           Package.resolved
-        key: ${{ matrix.cache-version }}-${{ runner.os }}-${{ steps.get-swift-version.outputs.version }}-${{ env.cache_version }}-spm-deps-${{ hashFiles('**/Package.swift', '**/Package.resolved') }}
+        key: ${{ matrix.cache-version }}-${{ runner.os }}-${{ steps.get-swift-version.outputs.version }}-${{ env.cache_version }}-spm-deps-${{ hashFiles('Package.swift', 'Package.resolved') }}
         restore-keys: |
           ${{ matrix.cache-version }}-${{ runner.os }}-${{ steps.get-swift-version.outputs.version }}-${{ env.cache_version }}-spm-deps-
     - name: Resolve dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,8 +59,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift: ["5.5", "5.4", "5.3"]
+        swift: ["5.6", "5.5", "5.4", "5.3"]
         include:
+          - swift: "5.6"
+            container: "swift:5.6"
+            cache-version: 2
           - swift: "5.5"
             container: "swift:5.5"
             cache-version: 2


### PR DESCRIPTION
Before moving forward with #476, I wanted to also sort some unrelated CI issues with the Linux distributions. This change supersedes #465. 

I noticed that there was a strange issue when running more recent tests (you can see this on `master` too):

> ```
> Error: .github/workflows/test.yml (Line: 90, Col: 14):
> [2](https://github.com/peripheryapp/periphery/runs/5880997981?check_suite_focus=true#step:16:2)
> Error: The template is not valid. .github/workflows/test.yml (Line: 90, Col: 14): hashFiles('**/Package.swift, **/Package.resolved') failed. Fail to hash files under directory '/home/runner/work/periphery/periphery'
> ```

I found actions/runner#449, which suggests that maybe sometimes `hashFiles` would fail silently but now it will error instead. I'm not sure if its 100% related or not, but after [enabling some debug logging](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging), I found this in the logs:

> ```
> ##[debug]::debug::Search path '/home/runner/work/periphery/periphery'
> ##[debug][Error: EACCES: permission denied, scandir '/home/runner/work/periphery/periphery/.build/x86_64-unknown-linux-gnu/debug/ModuleCache'] {
> ##[debug]  errno: -13,
> ##[debug]  code: 'EACCES',
> ##[debug]  syscall: 'scandir',
> ##[debug]  path: '/home/runner/work/periphery/periphery/.build/x86_64-unknown-linux-gnu/debug/ModuleCache'
> ##[debug]}
> ##[debug]STDOUT/STDERR stream read finished.
> ##[debug]STDOUT/STDERR stream read finished.
> ##[debug]Finished process 5758 with exit code 1, and elapsed time 00:00:00.1914745.
> ```

While I don't know the exact cause, I think we only really needed to worry about hashing on the root level Package.swift/Package.resolved so I updated the `hashFiles` arguments to do just that. 

Additionally, I added Swift 5.6 to the matrix on the `linux` job, which should be good now thanks to #471 