### PR TITLE
Enable a more portable binary on macOS - Approach 2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "StaticSwiftSyntaxParser",
+        "repositoryURL": "https://gist.github.com/liamnichols/92f8fdcf2864d0fd1619a18828acafb8.git",
+        "state": {
+          "branch": "main",
+          "revision": "6e4cb9eb406d6acb5174202380d5407b132f7672",
+          "version": null
+        }
+      },
+      {
         "package": "AEXML",
         "repositoryURL": "https://github.com/tadija/AEXML",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://gist.github.com/liamnichols/92f8fdcf2864d0fd1619a18828acafb8.git",
         "state": {
           "branch": "main",
-          "revision": "6e4cb9eb406d6acb5174202380d5407b132f7672",
+          "revision": "4134efa908ee6932f62f243cd1815000e51f44c6",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,15 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "StaticSwiftSyntaxParser",
-        "repositoryURL": "https://gist.github.com/liamnichols/92f8fdcf2864d0fd1619a18828acafb8.git",
-        "state": {
-          "branch": "main",
-          "revision": "4134efa908ee6932f62f243cd1815000e51f44c6",
-          "version": null
-        }
-      },
-      {
         "package": "AEXML",
         "repositoryURL": "https://github.com/tadija/AEXML",
         "state": {
@@ -57,11 +48,11 @@
       },
       {
         "package": "SwiftSyntax",
-        "repositoryURL": "https://github.com/apple/swift-syntax",
+        "repositoryURL": "https://github.com/liamnichols/swift-syntax",
         "state": {
           "branch": null,
-          "revision": "0b6c22b97f8e9320bca62e82cdbee601cf37ad3f",
-          "version": "0.50600.1"
+          "revision": "8a82bdb5d1558d130f732ef9f27dc1cd6f6696ea",
+          "version": "0.50600.1-static"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -48,7 +48,7 @@
       },
       {
         "package": "SwiftSyntax",
-        "repositoryURL": "https://github.com/liamnichols/swift-syntax",
+        "repositoryURL": "https://github.com/peripheryapp/swift-syntax",
         "state": {
           "branch": null,
           "revision": "8a82bdb5d1558d130f732ef9f27dc1cd6f6696ea",

--- a/Package.swift
+++ b/Package.swift
@@ -1,15 +1,36 @@
 // swift-tools-version:5.3
 import PackageDescription
 
+// Use the appropriate version of SwiftSyntax based on the current compiler
+#if compiler(>=5.5)
+let swiftSyntaxVersion: Package.Dependency.Requirement = .exact("0.50600.1")
+#elseif compiler(>=5.4)
+let swiftSyntaxVersion: Package.Dependency.Requirement = .exact("0.50400.0")
+#elseif compiler(>=5.3)
+let swiftSyntaxVersion: Package.Dependency.Requirement = .exact("0.50300.0")
+#else
+fatalError("This version of Periphery does not support Swift <= 5.2.")
+#endif
+
 var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-system", from: "1.0.0"),
     .package(url: "https://github.com/jpsim/Yams", from: "4.0.0"),
     .package(url: "https://github.com/tadija/AEXML", from: "4.0.0"),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
     .package(name: "SwiftIndexStore", url: "https://github.com/kateinoigakukun/swift-indexstore", from: "0.0.0"),
-    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax", .exact("0.50600.1")),
-    .package(name: "StaticSwiftSyntaxParser", url: "https://gist.github.com/liamnichols/92f8fdcf2864d0fd1619a18828acafb8.git", .branch("main"))
+    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax", swiftSyntaxVersion)
 ]
+
+// When on macOS, using SwiftSyntax for 5.6, also include StaticSwiftSyntaxParser to statically link internal dependencies
+#if os(macOS) && compiler(>=5.5)
+dependencies.append(
+    .package(
+        name: "StaticSwiftSyntaxParser",
+        url: "https://gist.github.com/liamnichols/92f8fdcf2864d0fd1619a18828acafb8.git",
+        .branch("main")
+    )
+)
+#endif
 
 #if os(macOS)
 dependencies.append(
@@ -39,13 +60,11 @@ var peripheryKitDependencies: [PackageDescription.Target.Dependency] = [
     .product(name: "SwiftIndexStore", package: "SwiftIndexStore")
 ]
 
-#if swift(>=5.6)
-peripheryKitDependencies.append(
-    .product(
-        name: "SwiftSyntaxParser",
-        package: "SwiftSyntax"
-    )
-)
+// Using Swift 5.5+, we need the SwiftSyntaxParser library, but on macOS specifically we also want to use the statically linked version
+#if os(macOS) && compiler(>=5.5)
+peripheryKitDependencies.append(.product(name: "StaticSwiftSyntaxParser", package: "StaticSwiftSyntaxParser"))
+#elseif compiler(>=5.5)
+peripheryKitDependencies.append(.product(name: "SwiftSyntaxParser", package: "SwiftSyntax"))
 #endif
 
 var targets: [PackageDescription.Target] = [
@@ -55,14 +74,7 @@ var targets: [PackageDescription.Target] = [
     ),
     .target(
         name: "PeripheryKit",
-        dependencies: [
-            .target(name: "Shared"),
-            .product(name: "SystemPackage", package: "swift-system"),
-            .product(name: "AEXML", package: "AEXML"),
-            .product(name: "SwiftSyntax", package: "SwiftSyntax"),
-            .product(name: "StaticSwiftSyntaxParser", package: "StaticSwiftSyntaxParser"),
-            .product(name: "SwiftIndexStore", package: "SwiftIndexStore")
-        ]
+        dependencies: peripheryKitDependencies
     ),
     .target(
         name: "Shared",

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,8 @@ var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/tadija/AEXML", from: "4.0.0"),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
     .package(name: "SwiftIndexStore", url: "https://github.com/kateinoigakukun/swift-indexstore", from: "0.0.0"),
-    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax", .exact("0.50600.1"))
+    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax", .exact("0.50600.1")),
+    .package(name: "StaticSwiftSyntaxParser", url: "https://gist.github.com/liamnichols/92f8fdcf2864d0fd1619a18828acafb8.git", .branch("main"))
 ]
 
 #if os(macOS)
@@ -59,15 +60,8 @@ var targets: [PackageDescription.Target] = [
             .product(name: "SystemPackage", package: "swift-system"),
             .product(name: "AEXML", package: "AEXML"),
             .product(name: "SwiftSyntax", package: "SwiftSyntax"),
-            .product(name: "SwiftSyntaxParser", package: "SwiftSyntax"),
-            .target(name: "lib_InternalSwiftSyntaxParser"),
+            .product(name: "StaticSwiftSyntaxParser", package: "StaticSwiftSyntaxParser"),
             .product(name: "SwiftIndexStore", package: "SwiftIndexStore")
-        ],
-        // Pass `-dead_strip_dylibs` to ignore the dynamic version of `lib_InternalSwiftSyntaxParser`
-        // that ships with SwiftSyntax because we want the static version from
-        // `StaticInternalSwiftSyntaxParser`.
-        linkerSettings: [
-            .unsafeFlags(["-Xlinker", "-dead_strip_dylibs"])
         ]
     ),
     .target(
@@ -129,11 +123,6 @@ var targets: [PackageDescription.Target] = [
             .target(name: "PeripheryKit")
         ],
         exclude: ["AccessibilityProject"]
-    ),
-    .binaryTarget(
-        name: "lib_InternalSwiftSyntaxParser",
-        url: "https://github.com/keith/StaticInternalSwiftSyntaxParser/releases/download/5.6/lib_InternalSwiftSyntaxParser.xcframework.zip",
-        checksum: "88d748f76ec45880a8250438bd68e5d6ba716c8042f520998a438db87083ae9d"
     )
 ]
 

--- a/Package.swift
+++ b/Package.swift
@@ -6,43 +6,9 @@ var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/jpsim/Yams", from: "4.0.0"),
     .package(url: "https://github.com/tadija/AEXML", from: "4.0.0"),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
-    .package(name: "SwiftIndexStore", url: "https://github.com/kateinoigakukun/swift-indexstore", from: "0.0.0")
+    .package(name: "SwiftIndexStore", url: "https://github.com/kateinoigakukun/swift-indexstore", from: "0.0.0"),
+    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax", .exact("0.50600.1"))
 ]
-#if swift(>=5.6)
-dependencies.append(
-    .package(
-        name: "SwiftSyntax",
-        url: "https://github.com/apple/swift-syntax",
-        .exact("0.50600.1")
-    )
-)
-#elseif swift(>=5.5)
-dependencies.append(
-    .package(
-        name: "SwiftSyntax",
-        url: "https://github.com/apple/swift-syntax",
-        .exact("0.50500.0")
-    )
-)
-#elseif swift(>=5.4)
-dependencies.append(
-    .package(
-        name: "SwiftSyntax",
-        url: "https://github.com/apple/swift-syntax",
-        .exact("0.50400.0")
-    )
-)
-#elseif swift(>=5.3)
-dependencies.append(
-    .package(
-        name: "SwiftSyntax",
-        url: "https://github.com/apple/swift-syntax",
-        .exact("0.50300.0")
-    )
-)
-#else
-fatalError("This version of Periphery does not support Swift <= 5.2.")
-#endif
 
 #if os(macOS)
 dependencies.append(
@@ -88,7 +54,21 @@ var targets: [PackageDescription.Target] = [
     ),
     .target(
         name: "PeripheryKit",
-        dependencies: peripheryKitDependencies
+        dependencies: [
+            .target(name: "Shared"),
+            .product(name: "SystemPackage", package: "swift-system"),
+            .product(name: "AEXML", package: "AEXML"),
+            .product(name: "SwiftSyntax", package: "SwiftSyntax"),
+            .product(name: "SwiftSyntaxParser", package: "SwiftSyntax"),
+            .target(name: "lib_InternalSwiftSyntaxParser"),
+            .product(name: "SwiftIndexStore", package: "SwiftIndexStore")
+        ],
+        // Pass `-dead_strip_dylibs` to ignore the dynamic version of `lib_InternalSwiftSyntaxParser`
+        // that ships with SwiftSyntax because we want the static version from
+        // `StaticInternalSwiftSyntaxParser`.
+        linkerSettings: [
+            .unsafeFlags(["-Xlinker", "-dead_strip_dylibs"])
+        ]
     ),
     .target(
         name: "Shared",
@@ -149,6 +129,11 @@ var targets: [PackageDescription.Target] = [
             .target(name: "PeripheryKit")
         ],
         exclude: ["AccessibilityProject"]
+    ),
+    .binaryTarget(
+        name: "lib_InternalSwiftSyntaxParser",
+        url: "https://github.com/keith/StaticInternalSwiftSyntaxParser/releases/download/5.6/lib_InternalSwiftSyntaxParser.xcframework.zip",
+        checksum: "88d748f76ec45880a8250438bd68e5d6ba716c8042f520998a438db87083ae9d"
     )
 ]
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
 // swift-tools-version:5.3
 import PackageDescription
 
-#if os(macOS) && compiler(>=5.5) || compiler(>=5.6)
-let swiftSyntaxVersion: Package.Dependency.Requirement = .exact("0.50600.1")
+#if compiler(>=5.6)
+let swiftSyntaxVersion: Package.Dependency.Requirement = .exact("0.50600.1-static")
 #elseif compiler(>=5.5)
-let swiftSyntaxVersion: Package.Dependency.Requirement = .exact("0.50500.0")
+let swiftSyntaxVersion: Package.Dependency.Requirement = .exact("0.50500.0-static")
 #elseif compiler(>=5.4)
 let swiftSyntaxVersion: Package.Dependency.Requirement = .exact("0.50400.0")
 #elseif compiler(>=5.3)
@@ -19,18 +19,8 @@ var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/tadija/AEXML", from: "4.0.0"),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
     .package(name: "SwiftIndexStore", url: "https://github.com/kateinoigakukun/swift-indexstore", from: "0.0.0"),
-    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax", swiftSyntaxVersion)
+    .package(name: "SwiftSyntax", url: "https://github.com/liamnichols/swift-syntax", swiftSyntaxVersion)
 ]
-
-#if os(macOS) && compiler(>=5.5)
-dependencies.append(
-    .package(
-        name: "StaticSwiftSyntaxParser",
-        url: "https://gist.github.com/liamnichols/92f8fdcf2864d0fd1619a18828acafb8.git",
-        .branch("main")
-    )
-)
-#endif
 
 #if os(macOS)
 dependencies.append(
@@ -60,9 +50,7 @@ var peripheryKitDependencies: [PackageDescription.Target.Dependency] = [
     .product(name: "SwiftIndexStore", package: "SwiftIndexStore")
 ]
 
-#if os(macOS) && compiler(>=5.5)
-peripheryKitDependencies.append(.product(name: "StaticSwiftSyntaxParser", package: "StaticSwiftSyntaxParser"))
-#elseif compiler(>=5.6)
+#if compiler(>=5.6)
 peripheryKitDependencies.append(.product(name: "SwiftSyntaxParser", package: "SwiftSyntax"))
 #endif
 

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/tadija/AEXML", from: "4.0.0"),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
     .package(name: "SwiftIndexStore", url: "https://github.com/kateinoigakukun/swift-indexstore", from: "0.0.0"),
-    .package(name: "SwiftSyntax", url: "https://github.com/liamnichols/swift-syntax", swiftSyntaxVersion)
+    .package(name: "SwiftSyntax", url: "https://github.com/peripheryapp/swift-syntax", swiftSyntaxVersion)
 ]
 
 #if os(macOS)

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.3
 import PackageDescription
 
 var dependencies: [Package.Dependency] = [

--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,10 @@
 // swift-tools-version:5.3
 import PackageDescription
 
-// Use the appropriate version of SwiftSyntax based on the current compiler
-#if compiler(>=5.5)
+#if os(macOS) && compiler(>=5.5) || compiler(>=5.6)
 let swiftSyntaxVersion: Package.Dependency.Requirement = .exact("0.50600.1")
+#elseif compiler(>=5.5)
+let swiftSyntaxVersion: Package.Dependency.Requirement = .exact("0.50500.0")
 #elseif compiler(>=5.4)
 let swiftSyntaxVersion: Package.Dependency.Requirement = .exact("0.50400.0")
 #elseif compiler(>=5.3)
@@ -21,7 +22,6 @@ var dependencies: [Package.Dependency] = [
     .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax", swiftSyntaxVersion)
 ]
 
-// When on macOS, using SwiftSyntax for 5.6, also include StaticSwiftSyntaxParser to statically link internal dependencies
 #if os(macOS) && compiler(>=5.5)
 dependencies.append(
     .package(
@@ -60,10 +60,9 @@ var peripheryKitDependencies: [PackageDescription.Target.Dependency] = [
     .product(name: "SwiftIndexStore", package: "SwiftIndexStore")
 ]
 
-// Using Swift 5.5+, we need the SwiftSyntaxParser library, but on macOS specifically we also want to use the statically linked version
 #if os(macOS) && compiler(>=5.5)
 peripheryKitDependencies.append(.product(name: "StaticSwiftSyntaxParser", package: "StaticSwiftSyntaxParser"))
-#elseif compiler(>=5.5)
+#elseif compiler(>=5.6)
 peripheryKitDependencies.append(.product(name: "SwiftSyntaxParser", package: "SwiftSyntax"))
 #endif
 

--- a/Sources/PeripheryKit/Syntax/MultiplexingSyntaxVisitor.swift
+++ b/Sources/PeripheryKit/Syntax/MultiplexingSyntaxVisitor.swift
@@ -1,9 +1,7 @@
 import Foundation
 import SystemPackage
 import SwiftSyntax
-#if swift(>=5.6)
 import SwiftSyntaxParser
-#endif
 
 protocol PeripherySyntaxVisitor {
     static func make(sourceLocationBuilder: SourceLocationBuilder) -> Self

--- a/Sources/PeripheryKit/Syntax/MultiplexingSyntaxVisitor.swift
+++ b/Sources/PeripheryKit/Syntax/MultiplexingSyntaxVisitor.swift
@@ -1,7 +1,9 @@
 import Foundation
 import SystemPackage
 import SwiftSyntax
+#if canImport(SwiftSyntaxParser)
 import SwiftSyntaxParser
+#endif
 
 protocol PeripherySyntaxVisitor {
     static func make(sourceLocationBuilder: SourceLocationBuilder) -> Self

--- a/Sources/PeripheryKit/Syntax/UnusedParameterParser.swift
+++ b/Sources/PeripheryKit/Syntax/UnusedParameterParser.swift
@@ -1,7 +1,9 @@
 import Foundation
 import SystemPackage
 import SwiftSyntax
+#if canImport(SwiftSyntaxParser)
 import SwiftSyntaxParser
+#endif
 
 protocol Item: AnyObject {
     var items: [Item] { get }

--- a/Sources/PeripheryKit/Syntax/UnusedParameterParser.swift
+++ b/Sources/PeripheryKit/Syntax/UnusedParameterParser.swift
@@ -1,9 +1,7 @@
 import Foundation
 import SystemPackage
 import SwiftSyntax
-#if swift(>=5.6)
 import SwiftSyntaxParser
-#endif
 
 protocol Item: AnyObject {
     var items: [Item] { get }

--- a/Tests/PeripheryTests/Syntax/TypeSyntaxInspectorTest.swift
+++ b/Tests/PeripheryTests/Syntax/TypeSyntaxInspectorTest.swift
@@ -1,7 +1,9 @@
 import Foundation
 import XCTest
 import SwiftSyntax
+#if canImport(SwiftSyntaxParser)
 import SwiftSyntaxParser
+#endif
 @testable import TestShared
 @testable import PeripheryKit
 

--- a/Tests/PeripheryTests/Syntax/TypeSyntaxInspectorTest.swift
+++ b/Tests/PeripheryTests/Syntax/TypeSyntaxInspectorTest.swift
@@ -1,9 +1,7 @@
 import Foundation
 import XCTest
 import SwiftSyntax
-#if swift(>=5.6)
 import SwiftSyntaxParser
-#endif
 @testable import TestShared
 @testable import PeripheryKit
 


### PR DESCRIPTION
# Background

- https://github.com/peripheryapp/periphery/issues/473

To make the `periphery` binary more portable on macOS, we want to have the lib_internalSwiftSyntaxParser library statically linked into the binary instead of having to link to a dylib version somewhere on the system.

# Approach 2

This is a second take on the approach used in #476, the main problem I'm trying to work around in these solutions is that I can't use binary targets in this Package.swift since it breaks `swift package describe` ([SR-15243](https://bugs.swift.org/browse/SR-15243) and [SR-15065](https://bugs.swift.org/browse/SR-15065)).

In this approach, I work around that by using a fork of the [apple/swift-syntax](https://github.com/apple/swift-syntax) repo where I have made some minor modifications to the Package.swift file so that the [StaticInternalSwiftSyntaxParser](https://github.com/keith/StaticInternalSwiftSyntaxParser/) dependency is properly declared on the SwiftSyntax/SwiftSyntaxParser targets directly.

While forking the official dependency is somewhat of an inconvenience, it feels like the 'cleanest' approach since it avoids having to do other workarounds like the one used in the first approach, or like those that have to exist in [SwiftLint](https://github.com/realm/SwiftLint/blob/5d7394be0ed2cce8268cd2b6cd24ecfb15005ab8/Package.swift#L54-L57)/[Sourcery](https://github.com/krzysztofzablocki/Sourcery/blob/fa3b01b8a721113076122f19c8354a351b0dc4f8/Package.swift#L63-L68).

Since the fork is only used to reconfigure the Package.swift, it doesn't feel like that big of a problem (we're just using it to re-tag the releases after patching), but ideally I'd like to transfer the fork/tags into the peripheryapp org as well.

Here are the diffs between the new tags in swift-syntax repo:

https://github.com/apple/swift-syntax/compare/0.50600.1...liamnichols:0.50600.1-static
https://github.com/apple/swift-syntax/compare/0.50500.0...liamnichols:0.50500.0-static 


