### PR TITLE
Fix `make build_release` after changes to lib_internalSwiftSyntaxParser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,22 @@
-RELEASE_BUILD_FLAGS=-c release --disable-sandbox --arch x86_64 --arch arm64
-BIN_PATH=$(shell swift build $(RELEASE_BUILD_FLAGS) --show-bin-path)/periphery
+BUILD_PATH=.build
+SWIFT_BUILD_FLAGS=--configuration release --disable-sandbox --build-path ${BUILD_PATH}
 
-build_release:
-	@swift build $(RELEASE_BUILD_FLAGS)
-	@install_name_tool -add_rpath @loader_path ${BIN_PATH}
+EXECUTABLE_X86_64=$(shell swift build ${SWIFT_BUILD_FLAGS} --arch x86_64 --show-bin-path)/periphery
+EXECUTABLE_ARM64=$(shell swift build ${SWIFT_BUILD_FLAGS} --arch arm64 --show-bin-path)/periphery
+EXECUTABLE=${BUILD_PATH}/periphery
+
+clean:
+	@swift package clean
+
+build_x86_64:
+	@swift build ${SWIFT_BUILD_FLAGS} --arch x86_64
+
+build_arm64:
+	@swift build ${SWIFT_BUILD_FLAGS} --arch arm64
+
+build_release: clean build_x86_64 build_arm64
+	@lipo -create -output ${EXECUTABLE} ${EXECUTABLE_X86_64} ${EXECUTABLE_ARM64}
+	@strip -rSTX ${EXECUTABLE}
 
 show_bin_path:
-	@echo ${BIN_PATH}
+	@echo ${EXECUTABLE}


### PR DESCRIPTION
# Background 

- #473
- #480
- #490
- https://github.com/apple/swift/issues/58079

After switching to using StaticInternalSwiftSyntax parser on macOS, we become impacted by a bug when trying to build a fat binary:

> Note: because of [this bug](https://bugs.swift.org/browse/SR-15802) if you want to depend on this target in SwiftPM and target multiple architectures in a single build, you must only depend on it from top level targets such as a test or executable target.

The problem comes when trying to use `swift build --arch arm64 --arch x86_64` however I originally didn't think that we were doing this and forgot to check the Makefile. After seeing the issue reported in #490, I realised that we do need to work around this.

# Changes

In this change, I follow the workaround that is used both in [SwiftLint](https://github.com/realm/SwiftLint/blob/ea6cc508906ed6e69fd42d10c2f315dc6080831f/Makefile#L71-L84) and [Sourcery](https://github.com/krzysztofzablocki/Sourcery/blob/9616fade78c7a79f257c7b9b401a71820b501101/Rakefile#L67-L70), which avoid the bug by building the arm64 and x86_64 binaries separately and then using `otool` to merge them together into one universal binary.

