### PR TITLE
Fix for projects in groups with no physical folder

### DIFF
--- a/Sources/XcodeSupport/XcodeWorkspace.swift
+++ b/Sources/XcodeSupport/XcodeWorkspace.swift
@@ -57,7 +57,7 @@ final class XcodeWorkspace: XcodeProjectlike {
         for child in elements {
             switch child {
             case .file(let ref):
-                let basePath = FilePath(groups.map { $0.location.path }.joined(separator: "/"))
+                let basePath = FilePath(groups.map { $0.location.path }.filter { !$0.isEmpty }.joined(separator: "/"))
                 let path = FilePath(ref.location.path)
                 let fullPath = basePath.pushing(path)
 


### PR DESCRIPTION
When placing project references in nested groups with no physical folder, the derived path would end up being absolute. (it would start with "/") because `["", ""].joined(separator: "/")` results in "/" (root). 

By filtering out empty locations before joining, this problem is avoided. There might be a better approach. (This PR serves dual purpose as issue report and suggested fix)