### PR TITLE
Add modules key to output of JSON formatter

### DIFF
--- a/Sources/Frontend/Formatters/JsonFormatter.swift
+++ b/Sources/Frontend/Formatters/JsonFormatter.swift
@@ -19,6 +19,7 @@ final class JsonFormatter: OutputFormatter {
         for result in results {
             let object: [AnyHashable: Any] = [
                 "kind": result.declaration.kind.rawValue,
+                "modules": Array(result.declaration.location.file.modules),
                 "name": result.declaration.name ?? "",
                 "modifiers": Array(result.declaration.modifiers),
                 "attributes": Array(result.declaration.attributes),
@@ -34,6 +35,7 @@ final class JsonFormatter: OutputFormatter {
                 for ref in references {
                     let object: [AnyHashable: Any] = [
                         "kind": ref.kind.rawValue,
+                        "modules": Array(result.declaration.location.file.modules),
                         "name": ref.name ?? "",
                         "modifiers": [],
                         "attributes": [],

--- a/Sources/Frontend/Formatters/JsonFormatter.swift
+++ b/Sources/Frontend/Formatters/JsonFormatter.swift
@@ -35,7 +35,6 @@ final class JsonFormatter: OutputFormatter {
                 for ref in references {
                     let object: [AnyHashable: Any] = [
                         "kind": ref.kind.rawValue,
-                        "modules": Array(result.declaration.location.file.modules),
                         "name": ref.name ?? "",
                         "modifiers": [],
                         "attributes": [],


### PR DESCRIPTION
## Problem

When Periphery finds a redundant public accessibility, it warns like `Class '<name>' is declared public, but not used outside of <module>`.
If Periphery receives `--format json` option, the output contains `<name>` but no information about `<module>` is found.

This is a bit inconvenient for those who want to parse Periphery's output by machine and reconstruct custom messages.

## Solution

So I added new `modules` key to JSON.