### PR TITLE
Update Periphery.podspec.template

### DIFF
--- a/scripts/Periphery.podspec.template
+++ b/scripts/Periphery.podspec.template
@@ -5,6 +5,6 @@ Pod::Spec.new do |spec|
   spec.homepage         = "https://github.com/peripheryapp/periphery"
   spec.license          = { :type => 'MIT', :file => 'LICENSE.md' }
   spec.author           = { "Ian Leitch" => "ian@leitch.io" }
-  spec.source           = { :http => "#{spec.homepage}/releases/download/#{spec.version}/periphery-v#{spec.version}.zip" }
+  spec.source           = { :git => 'https://github.com/peripheryapp/periphery.git', :tag => "'#{spec.version}'" }
   spec.preserve_paths   = '*'
 end


### PR DESCRIPTION
Follow the latest update from https://guides.cocoapods.org/syntax/podspec.html#specification to update pod spec.
Instead of point to download with exact link we point source to link git of project and tag release version. 