### PR TITLE
Implements CodeClimate Formatter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ##### Enhancements
 
-- None.
+- Add CodeClimate output formatter available via the `--format codeclimate` option. 
 
 ##### Bug Fixes
 

--- a/Sources/Frontend/Formatters/CodeClimateFormatter.swift
+++ b/Sources/Frontend/Formatters/CodeClimateFormatter.swift
@@ -1,0 +1,38 @@
+import Foundation
+import PeripheryKit
+
+final class CodeClimateFormatter: OutputFormatter {
+    
+    func format(_ results: [PeripheryKit.ScanResult]) throws -> String {
+        var jsonObject: [Any] = []
+
+        for result in results {
+            let lines: [AnyHashable: Any] = [
+                "begin": result.declaration.location.line
+            ]
+            
+            let location: [AnyHashable: Any] = [
+                "path": result.declaration.location.file.path.url.relativePath,
+                "lines": lines
+            ]
+            
+            let description = describe(result, colored: false)
+                .map { $0.1 }
+                .joined(separator: ", ")
+            
+            let object: [AnyHashable: Any] = [
+                "description": description,
+                "fingerprint": result.declaration.usrs.joined(separator: "."),
+                "severity": "major",
+                "location": location
+            ]
+            
+            jsonObject.append(object)
+        }
+
+        let data = try JSONSerialization.data(withJSONObject: jsonObject, options: [.prettyPrinted])
+        let json = String(data: data, encoding: .utf8)
+        return json ?? ""
+    }
+    
+}

--- a/Sources/Frontend/Formatters/OutputFormatter.swift
+++ b/Sources/Frontend/Formatters/OutputFormatter.swift
@@ -65,6 +65,8 @@ extension OutputFormat {
             return XcodeFormatter.self
         case .csv:
             return CsvFormatter.self
+        case .codeclimate:
+            return CodeClimateFormatter.self
         case .json:
             return JsonFormatter.self
         case .checkstyle:

--- a/Sources/Shared/OutputFormat.swift
+++ b/Sources/Shared/OutputFormat.swift
@@ -5,6 +5,7 @@ public enum OutputFormat: String, CaseIterable {
     case csv
     case json
     case checkstyle
+    case codeclimate
 
     public static let `default` = OutputFormat.xcode
 


### PR DESCRIPTION
This PR adds a CodeClimate Formatter for an integration into e.g. Gitlab according to the specification available on the [Gitlab Docs](https://docs.gitlab.com/ee/ci/testing/code_quality.html#implementing-a-custom-tool).

This allows (e.g.) Gitlab to parse and analyze the results of a scan to look for (newly) unused code and thus prevent the continual build-up of unused code within a project.