### PR TITLE
Calculate the fingerprint for an unused function parameter more statically

### DIFF
--- a/Sources/Frontend/Formatters/CodeClimateFormatter.swift
+++ b/Sources/Frontend/Formatters/CodeClimateFormatter.swift
@@ -20,9 +20,20 @@ final class CodeClimateFormatter: OutputFormatter {
                 .map { $0.1 }
                 .joined(separator: ", ")
             
+            let fingerprint: String
+            if result.declaration.kind == .varParameter,
+                let parentFingerprint = result.declaration.parent?.usrs.joined(separator: "."),
+                let argumentName = result.declaration.name {
+                // As function parameters do not have a mangled name that can be used for the fingerprint
+                // we take the mangled name of the function and append the position
+                fingerprint = "\(parentFingerprint)-\(argumentName)"
+            } else {
+                fingerprint = result.declaration.usrs.joined(separator: ".")
+            }
+            
             let object: [AnyHashable: Any] = [
                 "description": description,
-                "fingerprint": result.declaration.usrs.joined(separator: "."),
+                "fingerprint": fingerprint,
                 "severity": "major",
                 "location": location
             ]


### PR DESCRIPTION
The CodeClimate formatter recently introduced by @Schlabbi does its job very well! Unfortunately the generated fingerprint for unused function parameters changes too often (every time the source location changes). To make the fingerprint more statically, I adjusted the generation. Function parameter fingerprints are now calculated based on its function, together with its name. So the fingerprint only changes when the name of the function or the parameter changes.

Btw, thank you for this amazing project!