### PR TITLE
Enable integration via mint package manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,7 @@ var targets: [PackageDescription.Target] = [
             .product(name: "SystemPackage", package: "swift-system")
         ]
     ),
-    .target(
+    .testTarget(
         name: "TestShared",
         dependencies: [
             .target(name: "PeripheryKit")


### PR DESCRIPTION
Attempting to integration with [mint package manager](https://github.com/yonaskolb/Mint) resulted in a compilation failure. This compilation failure is due to the fact that a target (TestShared) is only used on other `.testTarget` but mint attempts to compile it and such compilation fails.

This PR addresses the issue by changing the target type for the `TestShared`.