### PR TITLE
Fix redundant accessibility analysis for function metatype arguments. Closes #574

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - `COMPILER_INDEX_STORE_ENABLE` is now forcefully enabled as it's required for indexing.
 - Fix false positive where a `typealias` is extended but otherwise unused.
+- Fix redundant accessibility analysis for function metatype arguments.
 
 ## 2.12.1 (2023-03-04)
 

--- a/Sources/PeripheryKit/Indexer/Declaration.swift
+++ b/Sources/PeripheryKit/Indexer/Declaration.swift
@@ -177,6 +177,7 @@ public final class Declaration {
     public var declaredType: String?
     public var letShorthandIdentifiers: Set<String> = []
     public var hasCapitalSelfFunctionCall: Bool = false
+    public var hasGenericFunctionReturnedMetatypeParameters: Bool = false
 
     public var parent: Declaration?
     var related: Set<Reference> = []

--- a/Sources/PeripheryKit/Indexer/Reference.swift
+++ b/Sources/PeripheryKit/Indexer/Reference.swift
@@ -7,18 +7,17 @@ public final class Reference {
         case genericRequirementType
         case inheritedClassType
         case refinedProtocolType
+        case variableInitFunctionCall
+        case functionCallMetatypeArgument
         case unknown
 
-        static var publiclyExposableRoles: [Role] {
-            return [
-                .varType,
-                .returnType,
-                .parameterType,
-                .genericParameterType,
-                .genericRequirementType,
-                .inheritedClassType,
-                .refinedProtocolType
-            ]
+        var isPubliclyExposable: Bool {
+            switch self {
+            case .varType, .returnType, .parameterType, .genericParameterType, .genericRequirementType, .inheritedClassType, .refinedProtocolType, .functionCallMetatypeArgument:
+                return true
+            default:
+                return false
+            }
         }
     }
 

--- a/Sources/PeripheryKit/Indexer/SwiftIndexer.swift
+++ b/Sources/PeripheryKit/Indexer/SwiftIndexer.swift
@@ -372,6 +372,7 @@ public final class SwiftIndexer: Indexer {
                 decl.declaredType = result.variableType
                 decl.letShorthandIdentifiers = result.letShorthandIdentifiers
                 decl.hasCapitalSelfFunctionCall = result.hasCapitalSelfFunctionCall
+                decl.hasGenericFunctionReturnedMetatypeParameters = result.hasGenericFunctionReturnedMetatypeParameters
 
                 for ref in decl.references.union(decl.related) {
                     if result.inheritedTypeLocations.contains(ref.location) {
@@ -390,6 +391,10 @@ public final class SwiftIndexer: Indexer {
                         ref.role = .genericParameterType
                     } else if result.genericConformanceRequirementLocations.contains(ref.location) {
                         ref.role = .genericRequirementType
+                    } else if result.variableInitFunctionCallLocations.contains(ref.location) {
+                        ref.role = .variableInitFunctionCall
+                    } else if result.functionCallMetatypeArgumentLocations.contains(ref.location) {
+                        ref.role = .functionCallMetatypeArgument
                     }
                 }
             }

--- a/Sources/PeripheryKit/Syntax/TypeSyntaxInspector.swift
+++ b/Sources/PeripheryKit/Syntax/TypeSyntaxInspector.swift
@@ -2,6 +2,11 @@ import Foundation
 import SwiftSyntax
 import Shared
 
+struct TypeNameSourceLocation: Hashable {
+    let name: String
+    let location: SourceLocation
+}
+
 struct TypeSyntaxInspector {
     let sourceLocationBuilder: SourceLocationBuilder
 
@@ -9,55 +14,60 @@ struct TypeSyntaxInspector {
         PropertyTypeSanitizer.sanitize(typeSyntax.description)
     }
 
-    func typeLocations(for typeSyntax: TypeSyntax) -> Set<SourceLocation> {
-        if let simpleType = typeSyntax.as(SimpleTypeIdentifierSyntax.self) {
-            // Simple type.
-            let location = nameTypeLocation(for: simpleType.name)
-            let genericTypeLocations = Set(simpleType.genericArgumentClause?.arguments.flatMap { typeLocations(for: $0.argumentType) } ?? [])
-            return genericTypeLocations.union([location])
-        } else if let optionalType = typeSyntax.as(OptionalTypeSyntax.self) {
-            // Optional type.
-            return typeLocations(for: optionalType.wrappedType)
-        } else if let memberType = typeSyntax.as(MemberTypeIdentifierSyntax.self) {
-            // Member type
-            let location = sourceLocationBuilder.location(at: memberType.name.positionAfterSkippingLeadingTrivia)
-            return typeLocations(for: memberType.baseType).union([location])
-        } else if let tuple = typeSyntax.as(TupleTypeSyntax.self) {
-            // Tuple type.
-            return Set(tuple.elements.flatMap { typeLocations(for: $0.type) })
-        } else if let funcType = typeSyntax.as(FunctionTypeSyntax.self) {
-            // Function type.
-            let locations = funcType.arguments.flatMap { typeLocations(for: $0.type) }
-            return typeLocations(for: funcType.output.returnType).union(locations)
-        } else if let arrayType = typeSyntax.as(ArrayTypeSyntax.self) {
-            // Array type.
-            return typeLocations(for: arrayType.elementType)
-        } else if let dictType = typeSyntax.as(DictionaryTypeSyntax.self) {
-            // Dictionary type.
-            return typeLocations(for: dictType.keyType).union(typeLocations(for: dictType.valueType))
-        } else if let someType = typeSyntax.as(ConstrainedSugarTypeSyntax.self) {
-            // Some type.
-            return typeLocations(for: someType.baseType)
-        } else if let implicitUnwrappedOptionalType = typeSyntax.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
-            // Implicitly unwrapped optional type.
-            return typeLocations(for: implicitUnwrappedOptionalType.wrappedType)
-        } else if let compositionType = typeSyntax.as(CompositionTypeSyntax.self) {
-            // Composition type.
-            return Set(compositionType.elements.flatMap { typeLocations(for: $0.type) })
-        } else if let attributedType = typeSyntax.as(AttributedTypeSyntax.self) {
-            // Attributed type.
-            return typeLocations(for: attributedType.baseType)
-        } else if let metatypeType = typeSyntax.as(MetatypeTypeSyntax.self) {
-            // Metatype type.
-            return typeLocations(for: metatypeType.baseType)
+    func typeNameLocations(for typeSyntax: TypeSyntax) -> Set<TypeNameSourceLocation> {
+        types(for: typeSyntax).mapSet {
+            .init(name: $0.trimmedDescription,
+                  location: sourceLocationBuilder.location(at: $0.positionAfterSkippingLeadingTrivia))
         }
+    }
 
-        return [sourceLocationBuilder.location(at: typeSyntax.positionAfterSkippingLeadingTrivia)]
+    func typeLocations(for typeSyntax: TypeSyntax) -> Set<SourceLocation> {
+        types(for: typeSyntax).mapSet { sourceLocationBuilder.location(at: $0.positionAfterSkippingLeadingTrivia) }
     }
 
     // MARK: - Private
 
-    private func nameTypeLocation(for name: TokenSyntax) -> SourceLocation {
-        sourceLocationBuilder.location(at: name.positionAfterSkippingLeadingTrivia)
+    func types(for typeSyntax: TypeSyntax) -> Set<TokenSyntax> {
+        if let simpleType = typeSyntax.as(SimpleTypeIdentifierSyntax.self) {
+            // Simple type.
+            var result = simpleType.genericArgumentClause?.arguments.flatMapSet { types(for: $0.argumentType) } ?? []
+            return result.inserting(simpleType.name)
+        } else if let optionalType = typeSyntax.as(OptionalTypeSyntax.self) {
+            // Optional type.
+            return types(for: optionalType.wrappedType)
+        } else if let memberType = typeSyntax.as(MemberTypeIdentifierSyntax.self) {
+            // Member type.
+            return types(for: memberType.baseType).union([memberType.name])
+        } else if let tuple = typeSyntax.as(TupleTypeSyntax.self) {
+            // Tuple type.
+            return tuple.elements.flatMapSet { types(for: $0.type) }
+        } else if let funcType = typeSyntax.as(FunctionTypeSyntax.self) {
+            // Function type.
+            let argumentTypes = funcType.arguments.flatMapSet { types(for: $0.type) }
+            return types(for: funcType.output.returnType).union(argumentTypes)
+        } else if let arrayType = typeSyntax.as(ArrayTypeSyntax.self) {
+            // Array type.
+            return types(for: arrayType.elementType)
+        } else if let dictType = typeSyntax.as(DictionaryTypeSyntax.self) {
+            // Dictionary type.
+            return types(for: dictType.keyType).union(types(for: dictType.valueType))
+        } else if let someType = typeSyntax.as(ConstrainedSugarTypeSyntax.self) {
+            // Some type.
+            return types(for: someType.baseType)
+        } else if let implicitUnwrappedOptionalType = typeSyntax.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
+            // Implicitly unwrapped optional type.
+            return types(for: implicitUnwrappedOptionalType.wrappedType)
+        } else if let compositionType = typeSyntax.as(CompositionTypeSyntax.self) {
+            // Composition type.
+            return Set(compositionType.elements.flatMap { types(for: $0.type) })
+        } else if let attributedType = typeSyntax.as(AttributedTypeSyntax.self) {
+            // Attributed type.
+            return types(for: attributedType.baseType)
+        } else if let metatypeType = typeSyntax.as(MetatypeTypeSyntax.self) {
+            // Metatype type.
+            return types(for: metatypeType.baseType)
+        }
+
+        return []
     }
 }

--- a/Sources/Shared/Extensions/Sequence+Extension.swift
+++ b/Sources/Shared/Extensions/Sequence+Extension.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-extension Sequence {
-    public func mapFirst<T>(_ transform: (Self.Element) throws -> T?) rethrows -> T? {
+public extension Sequence {
+    func mapFirst<T>(_ transform: (Element) throws -> T?) rethrows -> T? {
         for item in self {
             if let transformed = try transform(item) {
                 return transformed
@@ -9,5 +9,17 @@ extension Sequence {
         }
 
         return nil
+    }
+
+    func flatMapSet<T>(_ transform: (Element) throws -> Set<T>) rethrows -> Set<T> {
+        try reduce(into: .init()) { result, element in
+            result.formUnion(try transform(element))
+        }
+    }
+
+    func mapSet<T>(_ transform: (Element) throws -> T) rethrows -> Set<T> {
+        try reduce(into: .init()) { result, element in
+            result.insert(try transform(element))
+        }
     }
 }

--- a/Sources/Shared/Extensions/Set+Extension.swift
+++ b/Sources/Shared/Extensions/Set+Extension.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public extension Set {
+    mutating func inserting(_ value: Element) -> Self {
+        insert(value)
+        return self
+    }
+}

--- a/Tests/AccessibilityTests/AccessibilityProject/Sources/MainTarget/main.swift
+++ b/Tests/AccessibilityTests/AccessibilityProject/Sources/MainTarget/main.swift
@@ -6,9 +6,7 @@ PublicExtensionOnRedundantPublicKindRetainer().retain()
 IgnoreCommentCommandRetainer().retain()
 IgnoreAllCommentCommandRetainer().retain()
 
-_ = PublicTypeUsedAsPublicPropertyTypeRetainer().retain1
-_ = PublicTypeUsedAsPublicPropertyTypeRetainer().retain2
-_ = PublicTypeUsedAsPublicPropertyTypeRetainer().retain3
+_ = PublicTypeUsedAsPublicPropertyTypeRetainer().retain
 
 _ = PublicTypeUsedAsPublicInitializerParameterTypeRetainer()
 
@@ -28,6 +26,8 @@ PublicTypeUsedAsPublicFunctionGenericParameterRetainer().retain(PublicTypeUsedAs
 PublicTypeUsedAsPublicFunctionGenericRequirementRetainer().retain(PublicTypeUsedAsPublicFunctionGenericRequirement_ConformingClass.self)
 _ = PublicTypeUsedAsPublicClassGenericParameterRetainer<PublicTypeUsedAsPublicClassGenericParameter_ConformingClass>()
 _ = PublicTypeUsedAsPublicClassGenericRequirementRetainer<PublicTypeUsedAsPublicClassGenericRequirement_ConformingClass>()
+
+_ = PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnTypeRetainer().retain
 
 _ = NotRedundantPublicTestableImportClass().testableProperty
 

--- a/Tests/AccessibilityTests/AccessibilityProject/Sources/TargetA/PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType.swift
+++ b/Tests/AccessibilityTests/AccessibilityProject/Sources/TargetA/PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType.swift
@@ -1,0 +1,59 @@
+public protocol PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType1 {}
+public protocol PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType2 {}
+public protocol PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType3 {}
+public protocol PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType4 {}
+public protocol PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType5 {}
+public protocol PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType6 {}
+public protocol PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType7 {}
+public protocol PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType8 {}
+public protocol PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType9 {}
+public protocol PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType10_1 {}
+public protocol PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType10_2 {}
+public protocol PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType10_3 {}
+
+public class PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnTypeRetainer {
+    public init() {}
+
+    public var retain: [Any] {
+        [retain1, retain2, retain3, retain4, retain5, retain6, retain7, retain8, retain9, retain10]
+    }
+
+    public let retain1 = simpleReturn(PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType1.self)
+    public let (retain2, retain3, retain4) = (
+        simpleReturn(PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType2.self),
+        simpleReturn(PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType3.self),
+        nonMetatypeReturn(PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType4.self)
+    )
+    public let (retain5, (retain6, retain7)) = (simpleReturn(PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType5.self), (simpleReturn(PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType6.self), simpleReturn(PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType7.self)))
+    public let retain8 = closureReturn(PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType8.self)
+    public let retain9 = closureParameter(PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType9.self)
+    public let retain10 = multipleParameters(
+        PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType10_1.self,
+        PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType10_2.self,
+        PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType10_3.self
+    )
+
+    private static func closureReturn<T>(_ type: T.Type) -> () -> T {
+        fatalError()
+    }
+
+    private static func closureParameter<T>(_ type: T.Type) -> (T) -> Void {
+        fatalError()
+    }
+
+    private static func simpleReturn<T>(_ type: T.Type) -> T {
+        fatalError()
+    }
+
+    /// Even though C is not returned, it's assumed to be publicly accessible because it's too
+    /// complex to solve for the scenario where the call site argument positions do not match the
+    /// function signature parameter positions. Parameters with default arguments can result in
+    /// misalignment.
+    private static func multipleParameters<A, B, C>(_ typeA: A.Type, _ typeB: B.Type, _ typeC: C.Type) -> (A, B) {
+        fatalError()
+    }
+
+    private static func nonMetatypeReturn<T>(_ type: T.Type) -> String {
+        ""
+    }
+}

--- a/Tests/AccessibilityTests/AccessibilityProject/Sources/TargetA/PublicTypeUsedAsPublicPropertyType.swift
+++ b/Tests/AccessibilityTests/AccessibilityProject/Sources/TargetA/PublicTypeUsedAsPublicPropertyType.swift
@@ -1,12 +1,21 @@
 import Foundation
 
-public class PublicTypeUsedAsPublicPropertyType {}
+public class PublicTypeUsedAsPublicPropertyType1 {}
+public class PublicTypeUsedAsPublicPropertyType2 {}
+public class PublicTypeUsedAsPublicPropertyType3 {}
+public class PublicTypeUsedAsPublicPropertyType4 {}
 public struct PublicTypeUsedAsPublicPropertyGenericArgumentType: Hashable {}
 public class PublicTypeUsedAsPublicPropertyArrayType {}
 
 public class PublicTypeUsedAsPublicPropertyTypeRetainer {
     public init() {}
-    public var retain1: PublicTypeUsedAsPublicPropertyType?
+
+    public var retain: [Any?] {
+        [retain1, retain2, retain3, retain4, retain5, retain6]
+    }
+
+    public var retain1: PublicTypeUsedAsPublicPropertyType1?
     public var retain2: Set<PublicTypeUsedAsPublicPropertyGenericArgumentType>?
     public var retain3: [PublicTypeUsedAsPublicPropertyArrayType] = []
+    public var (retain4, (retain5, retain6)): (PublicTypeUsedAsPublicPropertyType2, (PublicTypeUsedAsPublicPropertyType3, PublicTypeUsedAsPublicPropertyType4)) = (.init(), (.init(), .init()))
 }

--- a/Tests/AccessibilityTests/RedundantPublicAccessibilityTest.swift
+++ b/Tests/AccessibilityTests/RedundantPublicAccessibilityTest.swift
@@ -31,7 +31,10 @@ class RedundantPublicAccessibilityTest: SourceGraphTestCase {
     }
 
     func testPublicTypeUsedAsPublicPropertyType() {
-        assertNotRedundantPublicAccessibility(.class("PublicTypeUsedAsPublicPropertyType"))
+        assertNotRedundantPublicAccessibility(.class("PublicTypeUsedAsPublicPropertyType1"))
+        assertNotRedundantPublicAccessibility(.class("PublicTypeUsedAsPublicPropertyType2"))
+        assertNotRedundantPublicAccessibility(.class("PublicTypeUsedAsPublicPropertyType3"))
+        assertNotRedundantPublicAccessibility(.class("PublicTypeUsedAsPublicPropertyType4"))
         assertNotRedundantPublicAccessibility(.struct("PublicTypeUsedAsPublicPropertyGenericArgumentType"))
         assertNotRedundantPublicAccessibility(.class("PublicTypeUsedAsPublicPropertyArrayType"))
     }
@@ -143,5 +146,22 @@ class RedundantPublicAccessibilityTest: SourceGraphTestCase {
     func testPublicTypeUsedInPublicClosure() {
         assertNotRedundantPublicAccessibility(.class("PublicTypeUsedInPublicClosureReturnType"))
         assertNotRedundantPublicAccessibility(.class("PublicTypeUsedInPublicClosureInputType"))
+    }
+
+    func testFunctionMetatypeParameterUsedAsGenericReturnType() {
+        assertNotRedundantPublicAccessibility(.protocol("PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType1"))
+        assertNotRedundantPublicAccessibility(.protocol("PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType2"))
+        assertNotRedundantPublicAccessibility(.protocol("PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType3"))
+        assertNotRedundantPublicAccessibility(.protocol("PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType5"))
+        assertNotRedundantPublicAccessibility(.protocol("PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType6"))
+        assertNotRedundantPublicAccessibility(.protocol("PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType7"))
+        assertNotRedundantPublicAccessibility(.protocol("PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType8"))
+        assertNotRedundantPublicAccessibility(.protocol("PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType9"))
+        assertNotRedundantPublicAccessibility(.protocol("PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType10_1"))
+        assertNotRedundantPublicAccessibility(.protocol("PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType10_2"))
+        assertNotRedundantPublicAccessibility(.protocol("PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType10_3"))
+
+        // Destructured binding control.
+        assertRedundantPublicAccessibility(.protocol("PublicTypeUsedAsPublicFunctionMetatypeParameterWithGenericReturnType4"))
     }
 }


### PR DESCRIPTION
Function metatype arguments to generic functions that also return the generic parameter may be publicly accessible.