### PR TITLE
Add support for `--working-directory`

### DIFF
--- a/Sources/Frontend/Commands/ScanCommand.swift
+++ b/Sources/Frontend/Commands/ScanCommand.swift
@@ -26,6 +26,9 @@ struct ScanCommand: FrontendCommand {
 
     @Option(parsing: .upToNextOption, help: "Path to file targets mapping. For use with third-party build systems. Multiple paths may be specified")
     var fileTargetsPath: [FilePath] = defaultConfiguration.$fileTargetsPath.defaultValue
+    
+    @Option(help: "Working directory for paths in file targets mapping. For use with third-party build systems")
+    var workingDirectory: FilePath = defaultConfiguration.$workingDirectory.defaultValue
 
     @Option(help: "Comma-separated list of schemes that must be built in order to produce the targets passed to the --targets option. Xcode projects only", transform: split(by: ","))
     var schemes: [String] = defaultConfiguration.$schemes.defaultValue
@@ -104,6 +107,7 @@ struct ScanCommand: FrontendCommand {
         configuration.apply(\.$workspace, workspace)
         configuration.apply(\.$project, project)
         configuration.apply(\.$fileTargetsPath, fileTargetsPath)
+        configuration.apply(\.$workingDirectory, workingDirectory)
         configuration.apply(\.$schemes, schemes)
         configuration.apply(\.$targets, targets)
         configuration.apply(\.$indexExclude, indexExclude)

--- a/Sources/PeripheryKit/Generic/GenericProjectDriver.swift
+++ b/Sources/PeripheryKit/Generic/GenericProjectDriver.swift
@@ -20,7 +20,7 @@ public final class GenericProjectDriver {
                     .fileTargets
                     .reduce(into: [FilePath: Set<String>](), { (result, tuple) in
                         let (key, value) = tuple
-                        let path = FilePath.makeAbsolute(key)
+                        let path = FilePath.makeAbsolute(key, relativeTo: configuration.workingDirectory)
 
                         if !path.exists {
                             throw PeripheryError.pathDoesNotExist(path: path.string)

--- a/Sources/PeripheryKit/Indexer/SwiftIndexer.swift
+++ b/Sources/PeripheryKit/Indexer/SwiftIndexer.swift
@@ -36,6 +36,9 @@ public final class SwiftIndexer: Indexer {
         excludedFiles.forEach { self.logger.debug("Excluding \($0.string)") }
 
         let unitsByFile: [FilePath: [(IndexStore, IndexStoreUnit)]] = try JobPool(jobs: indexStorePaths)
+            .map { [configuration] indexStorePath in
+                FilePath.makeAbsolute(indexStorePath.string, relativeTo: configuration.workingDirectory)
+            }
             .map { [logger] indexStorePath in
                 logger.debug("Reading \(indexStorePath)")
                 var unitsByFile: [FilePath: [(IndexStore, IndexStoreUnit)]] = [:]
@@ -44,7 +47,7 @@ public final class SwiftIndexer: Indexer {
                 try indexStore.forEachUnits(includeSystem: false) { unit -> Bool in
                     guard let filePath = try indexStore.mainFilePath(for: unit) else { return true }
 
-                    let file = FilePath.makeAbsolute(filePath)
+                    let file = FilePath.makeAbsolute(filePath, relativeTo: configuration.workingDirectory)
 
                     if includedFiles.contains(file) {
                         unitsByFile[file, default: []].append((indexStore, unit))

--- a/Sources/Shared/Configuration.swift
+++ b/Sources/Shared/Configuration.swift
@@ -20,6 +20,9 @@ public final class Configuration {
     @Setting(key: "file_targets_path", defaultValue: [], valueConverter: filePathConverter)
     public var fileTargetsPath: [FilePath]
 
+    @Setting(key: "working_directory", defaultValue: FilePath.current)
+    public var workingDirectory: FilePath
+
     @Setting(key: "format", defaultValue: .default, valueConverter: { OutputFormat(anyValue: $0) })
     public var outputFormat: OutputFormat
 


### PR DESCRIPTION
Allow the `periphery` command to be ran from a directory that isn't the root of the project/workspace/whatever-term (when interacting with relative paths in the inputs). The `--workspace-directory` will then be applied to source file, indexstore, and indexstore unit paths if they aren't already absolute.