### PR TITLE
Stabilize output by sorting modules

### DIFF
--- a/Sources/Frontend/Formatters/OutputFormatter.swift
+++ b/Sources/Frontend/Formatters/OutputFormatter.swift
@@ -47,7 +47,7 @@ extension OutputFormatter {
                     ($0.location, "Protocol '\(name)' conformance is redundant")
                 }
             case let .redundantPublicAccessibility(modules):
-                let modulesJoined = modules.joined(separator: ", ")
+                let modulesJoined = modules.sorted().joined(separator: ", ")
                 description += " is declared public, but not used outside of \(modulesJoined)"
             }
         } else {


### PR DESCRIPTION
Otherwise, the output changes randomly. As we commit the results to git to show changes in PRs, sorting the modules avoids unnecessary changes.