### PR TITLE
Set INDEX_ENABLE_DATA_STORE=YES in compiler settings

### DIFF
--- a/Sources/XcodeSupport/Xcodebuild.swift
+++ b/Sources/XcodeSupport/Xcodebuild.swift
@@ -36,7 +36,8 @@ public final class Xcodebuild {
             "CODE_SIGNING_ALLOWED=\"NO\"",
             "ENABLE_BITCODE=\"NO\"",
             "DEBUG_INFORMATION_FORMAT=\"dwarf\"",
-            "COMPILER_INDEX_STORE_ENABLE=\"YES\""
+            "COMPILER_INDEX_STORE_ENABLE=\"YES\"",
+            "INDEX_ENABLE_DATA_STORE=\"YES\""
         ]
 
         let xcodebuild = "xcodebuild \((args + [cmd] + envs + additionalArguments).joined(separator: " "))"


### PR DESCRIPTION
We were experiencing the same issue as described in https://github.com/peripheryapp/periphery/discussions/585: our build setup includes multiple schemes which reference xcconfig files, and Periphery always failed out of the box with the error message _Failed to find index datastore at path_. Looking into the DerivedData folder after the build, it was clear that error message was correct: the Index (or Index.noindex) directory was simply not being created when a build was run via Periphery, in spite of `COMPILER_INDEX_STORE_ENABLE` being set to `YES`.

By some miracle of random Googling, trial and error, and examining build logs, we came across the `INDEX_ENABLE_DATA_STORE` compiler setting. Lo and behold: by setting this to `YES`, Periphery works with our project without any issues.

I'm a bit wary of creating this PR, since I don't fully understand the interaction between `COMPILER_INDEX_STORE_ENABLE` and `INDEX_ENABLE_DATA_STORE`. I couldn't find any reliable documentation at all on `INDEX_ENABLE_DATA_STORE` - it's only mentioned indirectly on xcodebuildsettings.com [here](https://xcodebuildsettings.com/#mtl_enable_index_store). Nonetheless: it works, and maybe it will solve some compatibility issues for others experiencing something similar to https://github.com/peripheryapp/periphery/discussions/585.