### PR TITLE
Include Line and Column in Location for JSON and CSV Outputs - Issue 680

### DIFF
--- a/Sources/PeripheryKit/Formatters/CsvFormatter.swift
+++ b/Sources/PeripheryKit/Formatters/CsvFormatter.swift
@@ -63,7 +63,7 @@ final class CsvFormatter: OutputFormatter {
         let joinedModifiers = attributes.joined(separator: "|")
         let joinedAttributes = modifiers.joined(separator: "|")
         let joinedUsrs = usrs.joined(separator: "|")
-        let path = outputPath(location)
+        let path = locationDescription(location)
         return "\(kind),\(name ?? ""),\(joinedModifiers),\(joinedAttributes),\(accessibility ?? ""),\(joinedUsrs),\(path),\(hint ?? "")"
     }
 }

--- a/Sources/PeripheryKit/Formatters/JsonFormatter.swift
+++ b/Sources/PeripheryKit/Formatters/JsonFormatter.swift
@@ -23,7 +23,7 @@ final class JsonFormatter: OutputFormatter {
                 "accessibility": result.declaration.accessibility.value.rawValue,
                 "ids": Array(result.declaration.usrs),
                 "hints": [describe(result.annotation)],
-                "location": outputPath(result.declaration.location).string
+                "location": locationOutput(result.declaration.location)
             ]
             jsonObject.append(object)
 
@@ -38,7 +38,7 @@ final class JsonFormatter: OutputFormatter {
                         "accessibility": "",
                         "ids": [ref.usr],
                         "hints": [redundantConformanceHint],
-                        "location": outputPath(ref.location).string
+                        "location": locationOutput(ref.location)
                     ]
                     jsonObject.append(object)
                 }
@@ -50,5 +50,14 @@ final class JsonFormatter: OutputFormatter {
         let data = try JSONSerialization.data(withJSONObject: jsonObject, options: [.prettyPrinted, .withoutEscapingSlashes])
         let json = String(data: data, encoding: .utf8)
         return json ?? ""
+    }
+    
+    private func locationOutput(_ location: SourceLocation) -> String {
+        [
+            outputPath(location).string,
+            String(location.line),
+            String(location.column)
+        ]
+        .joined(separator: ":")
     }
 }

--- a/Sources/PeripheryKit/Formatters/JsonFormatter.swift
+++ b/Sources/PeripheryKit/Formatters/JsonFormatter.swift
@@ -23,7 +23,7 @@ final class JsonFormatter: OutputFormatter {
                 "accessibility": result.declaration.accessibility.value.rawValue,
                 "ids": Array(result.declaration.usrs),
                 "hints": [describe(result.annotation)],
-                "location": locationOutput(result.declaration.location)
+                "location": locationDescription(result.declaration.location)
             ]
             jsonObject.append(object)
 
@@ -38,7 +38,7 @@ final class JsonFormatter: OutputFormatter {
                         "accessibility": "",
                         "ids": [ref.usr],
                         "hints": [redundantConformanceHint],
-                        "location": locationOutput(ref.location)
+                        "location": locationDescription(ref.location)
                     ]
                     jsonObject.append(object)
                 }
@@ -50,14 +50,5 @@ final class JsonFormatter: OutputFormatter {
         let data = try JSONSerialization.data(withJSONObject: jsonObject, options: [.prettyPrinted, .withoutEscapingSlashes])
         let json = String(data: data, encoding: .utf8)
         return json ?? ""
-    }
-    
-    private func locationOutput(_ location: SourceLocation) -> String {
-        [
-            outputPath(location).string,
-            String(location.line),
-            String(location.column)
-        ]
-        .joined(separator: ":")
     }
 }

--- a/Sources/PeripheryKit/Formatters/OutputFormatter.swift
+++ b/Sources/PeripheryKit/Formatters/OutputFormatter.swift
@@ -68,6 +68,15 @@ extension OutputFormatter {
 
         return path
     }
+
+    func locationDescription(_ location: SourceLocation) -> String {
+        [
+            outputPath(location).string,
+            String(location.line),
+            String(location.column)
+        ]
+        .joined(separator: ":")
+    }
 }
 
 public extension OutputFormat {


### PR DESCRIPTION
This PR adds a `locationDescription` function to the OutputFormatter class. JsonFormatter and CsvFormatter both use this function to build the location included in their outputs, appending line and column to the file path created by `outputPath`. 

I compared the results of all supported output formats against version 2.16.0. Only the csv and json output formats had been affected by the regression from 2.16.0 to 2.17.0.