### PR TITLE
Add clarification about interface builder references

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Once indexing is complete, Periphery analyzes the graph to identify unused code.
 
 The goal of Periphery is to report instances of unused _declarations_. A declaration is a `class`, `struct`, `protocol`, `function`, `property`, `constructor`, `enum`, `typealias`, `associatedtype`, etc. As you'd expect, Periphery is able to identify simple unreferenced declarations, e.g a `class` that is no longer used anywhere in your codebase.
 
+If your project contains Interface Builder files (such as storyboards and XIBs), Periphery will take these into account when identifying unused declarations. However, Periphery currently only identifies unused classes. This limitation exists because Periphery does not yet parse Interface Builder files (see [Issue #212 on GitHub](https://github.com/peripheryapp/periphery/issues/212)). Due to Periphery's design principle of avoiding false positives, it is assumed that if a class is referenced in an Interface Builder file, all of its `IBOutlets` and `IBActions` are used, even if they might not be in reality. This approach will be revised to accurately identify unused `IBActions` and `IBOutlets` once Periphery gains the capability to parse Interface Builder files.
+
 Periphery can also identify more advanced instances of unused code. The following section explains these in detail.
 
 ### Function Parameters

--- a/README.md
+++ b/README.md
@@ -105,8 +105,6 @@ Once indexing is complete, Periphery analyzes the graph to identify unused code.
 
 The goal of Periphery is to report instances of unused _declarations_. A declaration is a `class`, `struct`, `protocol`, `function`, `property`, `constructor`, `enum`, `typealias`, `associatedtype`, etc. As you'd expect, Periphery is able to identify simple unreferenced declarations, e.g a `class` that is no longer used anywhere in your codebase.
 
-If your project contains Interface Builder files (such as storyboards and XIBs), Periphery will take these into account when identifying unused declarations. However, Periphery currently only identifies unused classes. This limitation exists because Periphery does not yet parse Interface Builder files (see [Issue #212 on GitHub](https://github.com/peripheryapp/periphery/issues/212)). Due to Periphery's design principle of avoiding false positives, it is assumed that if a class is referenced in an Interface Builder file, all of its `IBOutlets` and `IBActions` are used, even if they might not be in reality. This approach will be revised to accurately identify unused `IBActions` and `IBOutlets` once Periphery gains the capability to parse Interface Builder files.
-
 Periphery can also identify more advanced instances of unused code. The following section explains these in detail.
 
 ### Function Parameters
@@ -324,6 +322,10 @@ This property retention behavior is automatic, even when `Encodable` conformance
 ### XCTestCase
 
 Any class that inherits `XCTestCase` is automatically retained along with its test methods. However, when a class inherits `XCTestCase` indirectly via another class, e.g `UnitTestCase`, and that class resides in a target that isn't scanned by Periphery, you need to use the `--external-test-case-classes UnitTestCase` option to instruct Periphery to treat `UnitTestCase` as an `XCTestCase` subclass.
+
+### Interface Builder
+
+If your project contains Interface Builder files (such as storyboards and XIBs), Periphery will take these into account when identifying unused declarations. However, Periphery currently only identifies unused classes. This limitation exists because Periphery does not yet parse Interface Builder files (see [Issue #212 on GitHub](https://github.com/peripheryapp/periphery/issues/212)). Due to Periphery's design principle of avoiding false positives, it is assumed that if a class is referenced in an Interface Builder file, all of its `IBOutlets` and `IBActions` are used, even if they might not be in reality. This approach will be revised to accurately identify unused `IBActions` and `IBOutlets` once Periphery gains the capability to parse Interface Builder files.
 
 ## Comment Commands
 


### PR DESCRIPTION
Resolves https://github.com/peripheryapp/periphery/issues/663 — I created that issue because there was no info on the README. Since this has now been clarified, I'm documenting that knowledge in the README so it's available more easily.
Relates to https://github.com/peripheryapp/periphery/issues/212