### PR TITLE
Added schemes_arguments to configuration

### DIFF
--- a/Sources/Shared/Configuration.swift
+++ b/Sources/Shared/Configuration.swift
@@ -41,6 +41,9 @@ public final class Configuration {
     @Setting(key: "build_arguments", defaultValue: [])
     public var buildArguments: [String]
 
+    @Setting(key: "schemes_arguments", defaultValue: [])
+    public var schemesArguments: [String]
+
     @Setting(key: "retain_assign_only_property_types", defaultValue: [], valueSanitizer: PropertyTypeSanitizer.sanitize)
     public var retainAssignOnlyPropertyTypes: [String]
 
@@ -323,6 +326,8 @@ public final class Configuration {
                 $cleanBuild.assign(value)
             case $buildArguments.key:
                 $buildArguments.assign(value)
+            case $schemesArguments.key:
+                $schemesArguments.assign(value)
             case $relativeResults.key:
                 $relativeResults.assign(value)
             case $retainCodableProperties.key:

--- a/Sources/XcodeSupport/XcodeProject.swift
+++ b/Sources/XcodeSupport/XcodeProject.swift
@@ -105,8 +105,8 @@ final class XcodeProject: XcodeProjectlike {
         }
     }
 
-    func schemes() throws -> Set<String> {
-        try xcodebuild.schemes(project: self)
+    func schemes(additionalArguments: [String]) throws -> Set<String> {
+        try xcodebuild.schemes(project: self, additionalArguments: additionalArguments)
     }
 }
 

--- a/Sources/XcodeSupport/XcodeProjectDriver.swift
+++ b/Sources/XcodeSupport/XcodeProjectDriver.swift
@@ -47,7 +47,9 @@ public final class XcodeProjectDriver {
         }
 
         // Ensure schemes exist within the project
-        let schemes = try project.schemes().filter { configuration.schemes.contains($0) }
+        let schemes = try project.schemes(
+            additionalArguments: configuration.schemesArguments
+        ).filter { configuration.schemes.contains($0) }
         let validSchemeNames = schemes.mapSet { $0 }
 
         if let scheme = Set(configuration.schemes).subtracting(validSchemeNames).first {

--- a/Sources/XcodeSupport/XcodeProjectSetupGuide.swift
+++ b/Sources/XcodeSupport/XcodeProjectSetupGuide.swift
@@ -43,7 +43,10 @@ public final class XcodeProjectSetupGuide: SetupGuideHelpers, ProjectSetupGuide 
             print(colorize("Select build targets to analyze:", .bold))
             configuration.targets = select(multiple: targets, allowAll: true).selectedValues
 
-            let schemes = try filter(project.schemes(), project).map { $0 }.sorted()
+            let schemes = try filter(
+                project.schemes(additionalArguments: configuration.schemesArguments),
+                project
+            ).map { $0 }.sorted()
 
             print(colorize("\nSelect the schemes necessary to build your chosen targets:", .bold))
             configuration.schemes = select(multiple: schemes, allowAll: false).selectedValues
@@ -82,7 +85,11 @@ public final class XcodeProjectSetupGuide: SetupGuideHelpers, ProjectSetupGuide 
     private func getPodSchemes(in project: XcodeProjectlike) throws -> Set<String> {
         let path = project.sourceRoot.appending("Pods/Pods.xcodeproj")
         guard path.exists else { return [] }
-        return try xcodebuild.schemes(type: "project", path: path.lexicallyNormalized().string)
+        return try xcodebuild.schemes(
+            type: "project",
+            path: path.lexicallyNormalized().string,
+            additionalArguments: configuration.schemesArguments
+        )
     }
 
     private func filter(_ schemes: Set<String>, _ project: XcodeProjectlike) throws -> [String] {

--- a/Sources/XcodeSupport/XcodeProjectlike.swift
+++ b/Sources/XcodeSupport/XcodeProjectlike.swift
@@ -10,7 +10,7 @@ protocol XcodeProjectlike: AnyObject {
     var name: String { get }
     var sourceRoot: FilePath { get }
 
-    func schemes() throws -> Set<String>
+    func schemes(additionalArguments: [String]) throws -> Set<String>
 }
 
 extension XcodeProjectlike {

--- a/Sources/XcodeSupport/XcodeWorkspace.swift
+++ b/Sources/XcodeSupport/XcodeWorkspace.swift
@@ -42,8 +42,8 @@ final class XcodeWorkspace: XcodeProjectlike {
         }
     }
 
-    func schemes() throws -> Set<String> {
-        try xcodebuild.schemes(project: self)
+    func schemes(additionalArguments: [String]) throws -> Set<String> {
+        try xcodebuild.schemes(project: self, additionalArguments: additionalArguments)
     }
 
     // MARK: - Private

--- a/Tests/XcodeTests/XcodebuildTest.swift
+++ b/Tests/XcodeTests/XcodebuildTest.swift
@@ -36,7 +36,7 @@ class XcodebuildSchemesTest: XCTestCase {
     func testParseSchemes() {
         for output in XcodebuildListOutputs {
             shell.output = output
-            let schemes = try! xcodebuild.schemes(project: project)
+            let schemes = try! xcodebuild.schemes(project: project, additionalArguments: [])
             XCTAssertEqual(schemes, ["SchemeA", "SchemeB"])
         }
     }


### PR DESCRIPTION
Added additional arguments to the configuration to be passed to the xcodebuild schemes command.

In our CI build the cloned packages are saved in a custom path and we need to specify that path so the scheme call does not need to clone them again in the default directory:
```yaml
schemes_arguments:
- -clonedSourcePackagesDirPath 
- packages_cache
```