### PR TITLE
Ensure that classes that are never directly referenced are retained

### DIFF
--- a/Tests/Fixtures/RetentionFixtures/testRetainsClassUsedAsComputedVariableInExtension.swift
+++ b/Tests/Fixtures/RetentionFixtures/testRetainsClassUsedAsComputedVariableInExtension.swift
@@ -8,7 +8,7 @@ class SomeClass919: SomeProtocol919 {
 
 public struct DepsHandler {
     public func depsMethod() {
-        let _ = someProtocol
+        someProtocol.protocolMethod()
     }
 }
 

--- a/Tests/Fixtures/RetentionFixtures/testRetainsClassUsedAsComputedVariableInExtension.swift
+++ b/Tests/Fixtures/RetentionFixtures/testRetainsClassUsedAsComputedVariableInExtension.swift
@@ -7,7 +7,9 @@ class SomeClass919: SomeProtocol919 {
 }
 
 public struct DepsHandler {
-    public init() {}
+    public func depsMethod() {
+        let _ = someProtocol
+    }
 }
 
 extension DepsHandler {

--- a/Tests/Fixtures/RetentionFixtures/testRetainsClassUsedAsComputedVariableInExtension.swift
+++ b/Tests/Fixtures/RetentionFixtures/testRetainsClassUsedAsComputedVariableInExtension.swift
@@ -1,0 +1,17 @@
+protocol SomeProtocol919 {
+    func protocolMethod()
+}
+
+class SomeClass919: SomeProtocol919 {
+    func protocolMethod() {}
+}
+
+public struct DepsHandler {
+    public init() {}
+}
+
+extension DepsHandler {
+    var someProtocol: SomeProtocol919 {
+        SomeClass919()
+    }
+}

--- a/Tests/PeripheryTests/RetentionTest.swift
+++ b/Tests/PeripheryTests/RetentionTest.swift
@@ -1604,4 +1604,14 @@ final class RetentionTest: FixtureSourceGraphTestCase {
             }
         }
     }
+
+    func testRetainsClassUsedAsComputedVariableInExtension() {
+        analyze(retainPublic: true) {
+            assertReferenced(.struct("DepsHandler")) {
+                self.assertReferenced(.varInstance("someProtocol")) {
+                    self.assertReferenced(.class("SomeClass919"))
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Classes that are never referred to directly (only through protocols) should still be retained.