### PR TITLE
Added ability to read package manifest json from provided path

### DIFF
--- a/Sources/Frontend/Commands/ScanCommand.swift
+++ b/Sources/Frontend/Commands/ScanCommand.swift
@@ -114,6 +114,9 @@ struct ScanCommand: FrontendCommand {
     @Flag(help: "Only output results")
     var quiet: Bool = defaultConfiguration.$quiet.defaultValue
 
+    @Option(parsing: .upToNextOption, help: "JSON package manifest path (obtained using `swift package describe --type json` or manually)")
+    var jsonPackageManifestPath: [FilePath] = defaultConfiguration.$jsonPackageManifestPath.defaultValue
+
     private static let defaultConfiguration = Configuration()
 
     func run() throws {
@@ -162,6 +165,7 @@ struct ScanCommand: FrontendCommand {
         configuration.apply(\.$buildArguments, buildArguments)
         configuration.apply(\.$relativeResults, relativeResults)
         configuration.apply(\.$retainCodableProperties, retainCodableProperties)
+        configuration.apply(\.$jsonPackageManifestPath, jsonPackageManifestPath)
 
         try scanBehavior.main { project in
             try Scan().perform(project: project)

--- a/Sources/Frontend/Commands/ScanCommand.swift
+++ b/Sources/Frontend/Commands/ScanCommand.swift
@@ -114,8 +114,8 @@ struct ScanCommand: FrontendCommand {
     @Flag(help: "Only output results")
     var quiet: Bool = defaultConfiguration.$quiet.defaultValue
 
-    @Option(parsing: .upToNextOption, help: "JSON package manifest path (obtained using `swift package describe --type json` or manually)")
-    var jsonPackageManifestPath: [FilePath] = defaultConfiguration.$jsonPackageManifestPath.defaultValue
+    @Option(help: "JSON package manifest path (obtained using `swift package describe --type json` or manually)")
+    var jsonPackageManifestPath: String?
 
     private static let defaultConfiguration = Configuration()
 

--- a/Sources/PeripheryKit/SPM/SPM.swift
+++ b/Sources/PeripheryKit/SPM/SPM.swift
@@ -10,12 +10,21 @@ public struct SPM {
     }
 
     public struct Package: Decodable {
-        public static func load() throws -> Self {
+        public static func load(jsonPackageManifestPath: [FilePath] = []) throws -> Self {
             Logger().contextualized(with: "spm:package").debug("Loading \(FilePath.current)")
-            let jsonString = try Shell.shared.exec(["swift", "package", "describe", "--type", "json"], stderr: false)
 
-            guard let jsonData = jsonString.data(using: .utf8) else {
-                throw PeripheryError.packageError(message: "Failed to read swift package description.")
+            let jsonData: Data
+
+            if let path = jsonPackageManifestPath.first {
+                jsonData = try Data(contentsOf: path.url)
+            } else {
+                let jsonString = try Shell.shared.exec(["swift", "package", "describe", "--type", "json"], stderr: false)
+
+                guard let data = jsonString.data(using: .utf8) else {
+                    throw PeripheryError.packageError(message: "Failed to read swift package description.")
+                }
+
+                jsonData = data
             }
 
             let decoder = JSONDecoder()

--- a/Sources/PeripheryKit/SPM/SPM.swift
+++ b/Sources/PeripheryKit/SPM/SPM.swift
@@ -10,13 +10,13 @@ public struct SPM {
     }
 
     public struct Package: Decodable {
-        public static func load(jsonPackageManifestPath: [FilePath] = []) throws -> Self {
+        public static func load(jsonPackageManifestPath: String? = nil) throws -> Self {
             Logger().contextualized(with: "spm:package").debug("Loading \(FilePath.current)")
 
             let jsonData: Data
 
-            if let path = jsonPackageManifestPath.first {
-                jsonData = try Data(contentsOf: path.url)
+            if let jsonPackageManifestPath {
+                jsonData = try Data(contentsOf: URL(fileURLWithPath: jsonPackageManifestPath))
             } else {
                 let jsonString = try Shell.shared.exec(["swift", "package", "describe", "--type", "json"], stderr: false)
 

--- a/Sources/PeripheryKit/SPM/SPMProjectDriver.swift
+++ b/Sources/PeripheryKit/SPM/SPMProjectDriver.swift
@@ -5,7 +5,7 @@ import Shared
 public final class SPMProjectDriver {
     public static func build() throws -> Self {
         let configuration = Configuration.shared
-        let package = try SPM.Package.load()
+        let package = try SPM.Package.load(jsonPackageManifestPath: configuration.jsonPackageManifestPath)
         let targets: [SPM.Target]
 
         if !configuration.schemes.isEmpty {

--- a/Sources/Shared/Configuration.swift
+++ b/Sources/Shared/Configuration.swift
@@ -255,6 +255,10 @@ public final class Configuration {
             config[$retainCodableProperties.key] = retainCodableProperties
         }
 
+        if $jsonPackageManifestPath.hasNonDefaultValue {
+            config[$jsonPackageManifestPath.key] = jsonPackageManifestPath
+        }
+
         return try Yams.dump(object: config)
     }
 
@@ -340,6 +344,8 @@ public final class Configuration {
                 $relativeResults.assign(value)
             case $retainCodableProperties.key:
                 $retainCodableProperties.assign(value)
+            case $jsonPackageManifestPath.key:
+                $jsonPackageManifestPath.assign(value)
             default:
                 logger.warn("\(path.string): invalid key '\(key)'")
             }
@@ -380,6 +386,7 @@ public final class Configuration {
         $buildArguments.reset()
         $relativeResults.reset()
         $retainCodableProperties.reset()
+        $jsonPackageManifestPath.reset()
     }
 
     // MARK: - Helpers

--- a/Sources/Shared/Configuration.swift
+++ b/Sources/Shared/Configuration.swift
@@ -110,6 +110,9 @@ public final class Configuration {
     @Setting(key: "relative_results", defaultValue: false)
     public var relativeResults: Bool
 
+    @Setting(key: "json_package_manifest_path", defaultValue: [])
+    public var jsonPackageManifestPath: [FilePath]
+
     // Non user facing.
     public var guidedSetup: Bool = false
     public var removalOutputBasePath: FilePath?

--- a/Sources/Shared/Configuration.swift
+++ b/Sources/Shared/Configuration.swift
@@ -110,8 +110,8 @@ public final class Configuration {
     @Setting(key: "relative_results", defaultValue: false)
     public var relativeResults: Bool
 
-    @Setting(key: "json_package_manifest_path", defaultValue: [])
-    public var jsonPackageManifestPath: [FilePath]
+    @Setting(key: "json_package_manifest_path", defaultValue: nil)
+    public var jsonPackageManifestPath: String?
 
     // Non user facing.
     public var guidedSetup: Bool = false


### PR DESCRIPTION
Hello! I want to write a plugin for Swift Package Manager and I'm running into an issue where SPM doesn't allow to run `swift package describe` in plugins (due to plugin sandbox limitation). As a workaround we can perform this command manually (before plugin usage) or generate in the plugin using `PackagePlugin.Package/Target`. So I added an extra argument to the scan command - `--json-package-manifest-path` and serialize `SPM.Package` from that path if it exists.

You can check out the proof of concept for a possible Periphery plugin [here](https://github.com/rock88/PeripheryPlugin):

https://github.com/peripheryapp/periphery/assets/323908/1eb8458e-1856-4a1f-8fc9-aebbb817fbca


