### PR TITLE
Add a baseline capability to Periphery

### DIFF
--- a/Sources/Frontend/Commands/ScanBehavior.swift
+++ b/Sources/Frontend/Commands/ScanBehavior.swift
@@ -76,12 +76,13 @@ final class ScanBehavior {
                 do {
                     let baseline = try Baseline(fromPath: baselinePath)
                     filteredResults = baseline.filter(filteredResults)
-                } catch {
-                    if configuration.baseline == configuration.writeBaseline {
-                       // print a warning
-                    } else {
-                        return .failure(.underlyingError(error))
+                } catch CocoaError.fileReadNoSuchFile {
+                    // print a warning
+                    if configuration.writeBaseline != configuration.baseline {
+//                        return .failure(.underlyingError(error))
                     }
+                } catch {
+                    return .failure(.underlyingError(error))
                 }
             }
 

--- a/Sources/Frontend/Commands/ScanBehavior.swift
+++ b/Sources/Frontend/Commands/ScanBehavior.swift
@@ -69,7 +69,7 @@ final class ScanBehavior {
             }
 
             if let baselineOutputPath = configuration.writeBaseline {
-                try Baseline.write(filteredResults, toPath: baselineOutputPath)
+                try Baseline(scanResults: filteredResults).write(toPath: baselineOutputPath)
             }
 
             if let baselinePath = configuration.baseline {

--- a/Sources/Frontend/Commands/ScanCommand.swift
+++ b/Sources/Frontend/Commands/ScanCommand.swift
@@ -123,6 +123,12 @@ struct ScanCommand: FrontendCommand {
     @Option(help: "JSON package manifest path (obtained using `swift package describe --type json` or manually)")
     var jsonPackageManifestPath: String?
 
+    @Option(help: "The path to a baseline file, which will be used to filter out detected violations.")
+    var baseline: String?
+
+    @Option(help: "The path to save detected violations to as a new baseline.")
+    var writeBaseline: String?
+
     private static let defaultConfiguration = Configuration()
 
     func run() throws {
@@ -174,6 +180,8 @@ struct ScanCommand: FrontendCommand {
         configuration.apply(\.$retainCodableProperties, retainCodableProperties)
         configuration.apply(\.$retainEncodableProperties, retainEncodableProperties)
         configuration.apply(\.$jsonPackageManifestPath, jsonPackageManifestPath)
+        configuration.apply(\.$baseline, baseline)
+        configuration.apply(\.$writeBaseline, writeBaseline)
 
         try scanBehavior.main { project in
             try Scan().perform(project: project)

--- a/Sources/PeripheryKit/Baseline.swift
+++ b/Sources/PeripheryKit/Baseline.swift
@@ -60,7 +60,7 @@ public struct Baseline: Equatable {
     /// - Returns: The new scanResults.
     public func filter(_ scanResults: [ScanResult]) -> [ScanResult] {
         BaselineResults(scanResults).groupedByFile().flatMap {
-            filter($1.resultsWithAbsolutePaths)
+            filterFileResults($1.resultsWithAbsolutePaths) // TODO: should it be absolute paths
         }
     }
 

--- a/Sources/PeripheryKit/Baseline.swift
+++ b/Sources/PeripheryKit/Baseline.swift
@@ -73,7 +73,7 @@ public struct Baseline: Equatable {
         }
 
         let relativePathResults = scanResults.baselineResults
-        guard relativePathResults != baselineResults else {
+        if relativePathResults == baselineResults {
             return []
         }
 
@@ -160,12 +160,8 @@ private extension Sequence where Element == BaselineResult {
         Dictionary(grouping: self, by: \.scanResult.declaration.location.file.path.string)
     }
 
-    func groupedByKind() -> ResultsPerKind {
-        Dictionary(grouping: self, by: \.scanResult.declaration.kind.rawValue)
-    }
-
-    func groupedByKind(filteredBy existingScanResults: [BaselineResult]) -> ResultsPerKind {
-        Set(self).subtracting(existingScanResults).groupedByKind()
+    func groupedByKind(filteredBy existingScanResults: [BaselineResult] = []) -> ResultsPerKind {
+        Dictionary(grouping: Set(self).subtracting(existingScanResults), by: \.scanResult.declaration.kind.rawValue)
     }
 }
 

--- a/Sources/PeripheryKit/Baseline.swift
+++ b/Sources/PeripheryKit/Baseline.swift
@@ -1,0 +1,295 @@
+import Foundation
+import SystemPackage
+
+private typealias GroupedResults = [String: [BaselineResult]]
+
+private struct BaselineResult: Codable, Equatable, Hashable {
+    let scanResult: ScanResult
+    let text: String
+    var key: String { text + scanResult.declaration.kind.rawValue }
+
+    init(scanResult: ScanResult, text: String) {
+        self.scanResult = scanResult.withRelativeLocation()
+        self.text = text
+    }
+}
+
+/// A set of scan results that can be used to filter newly detected results.
+public struct Baseline: Equatable {
+    private let baselineResults: GroupedResults
+
+    /// The stored scan results.
+    public var scanResults: [ScanResult] {
+        baselineResults.keys.sorted().flatMap({ baselineResults[$0]! }).resultsWithAbsolutePaths
+    }
+
+    /// Creates a `Baseline` from a saved file.
+    ///
+    /// - parameter fromPath: The path to read from.
+    public init(fromPath path: String) throws {
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        baselineResults = try JSONDecoder().decode(GroupedResults.self, from: data)
+    }
+
+    init(scanResults: [ScanResult]) {
+        let baselineResults = scanResults.baselineResults
+        self.baselineResults = baselineResults.groupedByFile()
+    }
+
+    /// Writes a `Baseline` to disk in JSON format.
+    ///
+    /// - parameter scanResults: The scan results to save.
+    /// - parameter toPath: The path to write to.
+    public static func write(_ scanResults: [ScanResult], toPath path: String) throws {
+        let baselineResults = scanResults.baselineResults
+        let results = baselineResults.groupedByFile()
+        try write(results, toPath: path)
+    }
+
+    private static func write(_ results: GroupedResults, toPath path: String) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted]
+        let data = try encoder.encode(results)
+        try data.write(to: URL(fileURLWithPath: path))
+    }
+
+    /// Filters out scan results that are present in the `Baseline`.
+    ///
+    /// - parameter scanResults: The scanResults to filter.
+    /// - Returns: The new scanResults.
+    public func filter(_ scanResults: [ScanResult]) -> [ScanResult] {
+        let scanResultsGroupedByFile = Dictionary(grouping: scanResults) {
+            $0.declaration.location.file.path.string
+        }
+
+        var results: [ScanResult] = []
+        for (_, value) in scanResultsGroupedByFile {
+            let filteredResults = filterFileResults(value)
+            results.append(contentsOf: filteredResults)
+        }
+        return results
+    }
+
+    private func filterFileResults(_ scanResults: [ScanResult]) -> [ScanResult] {
+        guard let firstResult = scanResults.first,
+              let baselineResults = baselineResults[firstResult.declaration.location.relativeLocation().file.path.string],
+              !baselineResults.isEmpty
+        else {
+            return scanResults
+        }
+
+        let relativePathResults = scanResults.baselineResults
+        guard relativePathResults != baselineResults else {
+            return []
+        }
+
+        let resultsByKind = relativePathResults.groupedByKind(
+            filteredBy: baselineResults
+        )
+        let baselineResultsByKind = baselineResults.groupedByKind(
+            filteredBy: relativePathResults
+        )
+
+        var filteredResults: Set<BaselineResult> = []
+
+        for (kind, results) in resultsByKind {
+            guard
+                let baselineResults = baselineResultsByKind[kind],
+                !baselineResults.isEmpty else {
+                filteredResults.formUnion(results)
+                continue
+            }
+
+            let groupedResults = Dictionary(grouping: results) { $0.key }
+            let groupedBaselineResults = Dictionary(grouping: baselineResults) { $0.key }
+
+            for (key, results) in groupedResults {
+                guard let baselineResults = groupedBaselineResults[key] else {
+                    filteredResults.formUnion(results)
+                    continue
+                }
+                if scanResults.count > baselineResults.count {
+                    filteredResults.formUnion(results)
+                }
+            }
+        }
+
+        let scanResultsWithAbsolutePaths = Set(filteredResults.resultsWithAbsolutePaths)
+        return scanResults.filter { scanResultsWithAbsolutePaths.contains($0) }
+    }
+}
+
+// MARK: - Private
+
+private extension Sequence where Element == ScanResult {
+    var baselineResults: [BaselineResult] {
+        var lines: [String: [String]] = [:]
+        var baselineResults: [BaselineResult] = []
+        for scanResult in self {
+            let absolutePath = scanResult.declaration.location.file.path.string
+            let lineNumber = scanResult.declaration.location.line - 1
+            guard lineNumber > 0 else {
+                baselineResults.append(BaselineResult(scanResult: scanResult, text: ""))
+                continue
+            }
+            if let fileLines = lines[absolutePath] {
+                let text = (!fileLines.isEmpty && lineNumber < fileLines.count ) ? fileLines[lineNumber] : ""
+                baselineResults.append(BaselineResult(scanResult: scanResult, text: text))
+                continue
+            }
+            let text: String
+            if let contents = try? String(contentsOfFile: absolutePath, encoding: .utf8) {
+                let fileLines = contents.components(separatedBy: CharacterSet.newlines)
+                if lineNumber < fileLines.count {
+                    text = fileLines[lineNumber]
+                    lines[absolutePath] = fileLines
+                } else {
+                    text = ""
+                }
+            } else {
+                text = ""
+            }
+            baselineResults.append(BaselineResult(scanResult: scanResult, text: text))
+        }
+        return baselineResults
+    }
+}
+
+private extension Sequence where Element == BaselineResult {
+    var resultsWithAbsolutePaths: [ScanResult] {
+        map {
+            $0.scanResult.withAbsoluteLocation()
+        }
+    }
+
+    func groupedByFile() -> GroupedResults {
+        Dictionary(grouping: self) {
+            $0.scanResult.declaration.location.file.path.string
+        }
+    }
+
+    func groupedByKind() -> GroupedResults {
+        Dictionary(grouping: self) { $0.scanResult.declaration.kind.rawValue }
+    }
+
+    func groupedByKind(filteredBy existingScanResults: [BaselineResult]) -> GroupedResults {
+        let setOfExistingScanResults = Set(existingScanResults)
+        let remainingScanResults = filter { !setOfExistingScanResults.contains($0) }
+        return remainingScanResults.groupedByKind()
+    }
+}
+
+private var currentFilePath: FilePath = { .current }()
+
+private extension ScanResult {
+    func withRelativeLocation() -> ScanResult {
+        ScanResult(
+            declaration: declaration.withRelativeLocation(),
+            annotation: annotation.withRelativeLocation()
+        )
+    }
+
+    func withAbsoluteLocation() -> ScanResult {
+        ScanResult(
+            declaration: declaration.withAbsoluteLocation(),
+            annotation: annotation.withAbsoluteLocation()
+        )
+    }
+}
+
+private extension Declaration {
+    func withRelativeLocation() -> Declaration {
+        Declaration(kind: kind, usrs: usrsWithRelativeLocation(), location: location.relativeLocation())
+    }
+
+    func withAbsoluteLocation() -> Declaration {
+        Declaration(kind: kind, usrs: usrsWithAbsoluteLocation(), location: location.absoluteLocation())
+    }
+
+    private func usrsWithRelativeLocation() -> Set<String> {
+        guard kind == .varParameter else {
+            return usrs
+        }
+        return Set(usrs.map {
+            let components = $0.split(separator: "-", maxSplits: 3)
+            guard components.count == 3 else {
+                return $0
+            }
+            let path = components[2].replacingOccurrences(of: currentFilePath.string + "/", with: "")
+            return "\(components[0])-\(components[1])-\(path)"
+        })
+    }
+
+    private func usrsWithAbsoluteLocation() -> Set<String> {
+        guard kind == .varParameter else {
+            return usrs
+        }
+        return Set(usrs.map {
+            let components = $0.split(separator: "-", maxSplits: 3)
+            guard components.count == 3 else {
+                return $0
+            }
+            let absolutePath = currentFilePath.string + "/" + components[2]
+            return "\(components[0])-\(components[1])-\(absolutePath)"
+        })
+    }
+}
+
+private extension SourceLocation {
+    func relativeLocation() -> SourceLocation {
+        let relativePath = relativePath(to: file.path)
+        let file = SourceFile(path: relativePath, modules: file.modules)
+        return SourceLocation(file: file, line: line, column: column)
+    }
+
+    func absoluteLocation() -> SourceLocation {
+        let absolutePath = FilePath(currentFilePath.string + "/" + file.path.string)
+        let file = SourceFile(path: absolutePath, modules: file.modules)
+        return SourceLocation(file: file, line: line, column: column)
+    }
+
+    private func relativePath(to absolutePath: FilePath) -> FilePath {
+        // FilePath.relativePath is very slow
+        let absolutePathString = absolutePath.string
+        let currentPathString = currentFilePath.string
+        let relativePathString = absolutePathString.replacingOccurrences(of: currentPathString + "/", with: "")
+        let relativePath = FilePath(relativePathString)
+        return relativePath
+    }
+}
+
+private extension ScanResult.Annotation {
+    func withRelativeLocation() -> ScanResult.Annotation {
+        switch self {
+        case .redundantProtocol(let references, let inherited):
+            return .redundantProtocol(
+                references: Set(references.map { $0.withRelativeLocation() }),
+                inherited: inherited
+            )
+        default:
+            return self
+        }
+    }
+
+    func withAbsoluteLocation() -> ScanResult.Annotation {
+        switch self {
+        case .redundantProtocol(let references, let inherited):
+            return .redundantProtocol(
+                references: Set(references.map { $0.withAbsoluteLocation() }),
+                inherited: inherited
+            )
+        default:
+            return self
+        }
+    }
+}
+
+private extension Reference {
+    func withRelativeLocation() -> Reference {
+        Reference(kind: kind, usr: usr, location: location.relativeLocation(), isRelated: isRelated)
+    }
+
+    func withAbsoluteLocation() -> Reference {
+        Reference(kind: kind, usr: usr, location: location.absoluteLocation(), isRelated: isRelated)
+    }
+}

--- a/Sources/PeripheryKit/Baseline.swift
+++ b/Sources/PeripheryKit/Baseline.swift
@@ -3,7 +3,7 @@ import SystemPackage
 
 private typealias GroupedResults = [String: [BaselineResult]]
 
-private struct BaselineResult: Codable, Equatable, Hashable {
+private struct BaselineResult: Codable, Hashable {
     let scanResult: ScanResult
     let text: String
     var key: String { text + scanResult.declaration.kind.rawValue }
@@ -100,8 +100,8 @@ public struct Baseline: Equatable {
                 continue
             }
 
-            let groupedResults = Dictionary(grouping: results) { $0.key }
-            let groupedBaselineResults = Dictionary(grouping: baselineResults) { $0.key }
+            let groupedResults = Dictionary(grouping: results, by: \.key)
+            let groupedBaselineResults = Dictionary(grouping: baselineResults, by: \.key)
 
             for (key, results) in groupedResults {
                 guard let baselineResults = groupedBaselineResults[key] else {
@@ -173,9 +173,7 @@ private extension Sequence where Element == BaselineResult {
     }
 
     func groupedByKind(filteredBy existingScanResults: [BaselineResult]) -> GroupedResults {
-        let setOfExistingScanResults = Set(existingScanResults)
-        let remainingScanResults = filter { !setOfExistingScanResults.contains($0) }
-        return remainingScanResults.groupedByKind()
+        Set(self).subtracting(existingScanResults).groupedByKind()
     }
 }
 

--- a/Sources/PeripheryKit/Baseline.swift
+++ b/Sources/PeripheryKit/Baseline.swift
@@ -31,25 +31,20 @@ public struct Baseline: Equatable {
         baselineResults = try JSONDecoder().decode(GroupedResults.self, from: data)
     }
 
-    init(scanResults: [ScanResult]) {
-        let baselineResults = scanResults.baselineResults
-        self.baselineResults = baselineResults.groupedByFile()
+    /// Creates a `Baseline` from a list of results.
+    ///
+    /// - parameter scanResults: The results for the baseline.
+    public init(scanResults: [ScanResult]) {
+        self.baselineResults = scanResults.baselineResults.groupedByFile()
     }
 
     /// Writes a `Baseline` to disk in JSON format.
     ///
-    /// - parameter scanResults: The scan results to save.
     /// - parameter toPath: The path to write to.
-    public static func write(_ scanResults: [ScanResult], toPath path: String) throws {
-        let baselineResults = scanResults.baselineResults
-        let results = baselineResults.groupedByFile()
-        try write(results, toPath: path)
-    }
-
-    private static func write(_ results: GroupedResults, toPath path: String) throws {
+    public func write(toPath path: String) throws {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted]
-        let data = try encoder.encode(results)
+        let data = try encoder.encode(baselineResults)
         try data.write(to: URL(fileURLWithPath: path))
     }
 

--- a/Sources/PeripheryKit/Indexer/Declaration.swift
+++ b/Sources/PeripheryKit/Indexer/Declaration.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 final class Declaration {
-    enum Kind: String, RawRepresentable, CaseIterable {
+    enum Kind: String, RawRepresentable, CaseIterable, Codable {
         case `associatedtype` = "associatedtype"
         case `class` = "class"
         case `enum` = "enum"
@@ -289,6 +289,15 @@ final class Declaration {
     func isDeclaredInExtension(kind: Declaration.Kind) -> Bool {
         guard let parent = parent else { return false }
         return parent.kind == kind
+    }
+}
+
+extension Declaration: Codable {
+    enum CodingKeys: CodingKey {
+        case location
+        case kind
+        case usrs
+        case hashValueCache
     }
 }
 

--- a/Sources/PeripheryKit/Indexer/Declaration.swift
+++ b/Sources/PeripheryKit/Indexer/Declaration.swift
@@ -227,7 +227,9 @@ final class Declaration {
     var isImplicit: Bool = false
     var isObjcAccessible: Bool = false
 
-    private let hashValueCache: Int
+    private lazy var hashValueCache: Int = {
+        usrs.hashValue
+    }()
 
     var ancestralDeclarations: Set<Declaration> {
         var maybeParent = parent
@@ -283,7 +285,6 @@ final class Declaration {
         self.kind = kind
         self.usrs = usrs
         self.location = location
-        self.hashValueCache = usrs.hashValue
     }
 
     func isDeclaredInExtension(kind: Declaration.Kind) -> Bool {
@@ -297,7 +298,6 @@ extension Declaration: Codable {
         case location
         case kind
         case usrs
-        case hashValueCache
     }
 }
 

--- a/Sources/PeripheryKit/Indexer/Reference.swift
+++ b/Sources/PeripheryKit/Indexer/Reference.swift
@@ -32,14 +32,15 @@ final class Reference {
     let usr: String
     var role: Role = .unknown
 
-    private let hashValueCache: Int
+    private lazy var hashValueCache: Int = {
+        [usr.hashValue, location.hashValue, isRelated.hashValue].hashValue
+    }()
 
     init(kind: Declaration.Kind, usr: String, location: SourceLocation, isRelated: Bool = false) {
         self.kind = kind
         self.usr = usr
         self.isRelated = isRelated
         self.location = location
-        self.hashValueCache = [usr.hashValue, location.hashValue, isRelated.hashValue].hashValue
     }
 
     var descendentReferences: Set<Reference> {
@@ -53,7 +54,6 @@ extension Reference: Codable {
         case kind
         case isRelated
         case usr
-        case hashValueCache
     }
 }
 

--- a/Sources/PeripheryKit/Indexer/Reference.swift
+++ b/Sources/PeripheryKit/Indexer/Reference.swift
@@ -47,6 +47,16 @@ final class Reference {
     }
 }
 
+extension Reference: Codable {
+    enum CodingKeys: CodingKey {
+        case location
+        case kind
+        case isRelated
+        case usr
+        case hashValueCache
+    }
+}
+
 extension Reference: Hashable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(hashValueCache)

--- a/Sources/PeripheryKit/Indexer/SourceFile.swift
+++ b/Sources/PeripheryKit/Indexer/SourceFile.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SystemPackage
 
-class SourceFile {
+class SourceFile: Codable {
     let path: FilePath
     let modules: Set<String>
     var importStatements: [ImportStatement] = []
@@ -9,6 +9,11 @@ class SourceFile {
     init(path: FilePath, modules: Set<String>) {
         self.path = path
         self.modules = modules
+    }
+
+    enum CodingKeys: CodingKey {
+        case path
+        case modules
     }
 }
 

--- a/Sources/PeripheryKit/Indexer/SourceLocation.swift
+++ b/Sources/PeripheryKit/Indexer/SourceLocation.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class SourceLocation {
+class SourceLocation: Codable {
     let file: SourceFile
     let line: Int
     let column: Int

--- a/Sources/PeripheryKit/Indexer/SourceLocation.swift
+++ b/Sources/PeripheryKit/Indexer/SourceLocation.swift
@@ -5,13 +5,14 @@ class SourceLocation: Codable {
     let line: Int
     let column: Int
 
-    private let hashValueCache: Int
+    private lazy var hashValueCache: Int = {
+        [file.hashValue, line, column].hashValue
+    }()
 
     init(file: SourceFile, line: Int, column: Int) {
         self.file = file
         self.line = line
         self.column = column
-        self.hashValueCache = [file.hashValue, line, column].hashValue
     }
 
     // MARK: - Private
@@ -37,7 +38,6 @@ extension SourceLocation: Equatable {
 
 extension SourceLocation: Hashable {
     func hash(into hasher: inout Hasher) {
-
         hasher.combine(hashValueCache)
     }
 }

--- a/Sources/PeripheryKit/ScanResult.swift
+++ b/Sources/PeripheryKit/ScanResult.swift
@@ -6,18 +6,18 @@ public struct ScanResult: Codable, Hashable {
         case assignOnlyProperty
         case redundantProtocol(references: Set<Reference>, inherited: Set<String>)
         case redundantPublicAccessibility(modules: Set<String>)
-        
+
         enum CodingKeys: CodingKey {
             case unused
             case assignOnlyProperty
             case redundantProtocol
             case redundantPublicAccessibility
         }
-        
+
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             let key = container.allKeys.first
-            
+
             switch key {
             case .unused:
                 self = .unused
@@ -37,10 +37,10 @@ public struct ScanResult: Codable, Hashable {
                 )
             }
         }
-        
+
         func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
-            
+
             switch self {
             case .unused:
                 try container.encode(true, forKey: .unused)
@@ -55,7 +55,7 @@ public struct ScanResult: Codable, Hashable {
             }
         }
     }
-    
+
     let declaration: Declaration
     let annotation: Annotation
 }

--- a/Sources/PeripheryKit/ScanResult.swift
+++ b/Sources/PeripheryKit/ScanResult.swift
@@ -6,8 +6,56 @@ public struct ScanResult: Codable, Hashable {
         case assignOnlyProperty
         case redundantProtocol(references: Set<Reference>, inherited: Set<String>)
         case redundantPublicAccessibility(modules: Set<String>)
+        
+        enum CodingKeys: CodingKey {
+            case unused
+            case assignOnlyProperty
+            case redundantProtocol
+            case redundantPublicAccessibility
+        }
+        
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let key = container.allKeys.first
+            
+            switch key {
+            case .unused:
+                self = .unused
+            case .assignOnlyProperty:
+                self = .assignOnlyProperty
+            case .redundantProtocol:
+                var nestedContainer = try container.nestedUnkeyedContainer(forKey: .redundantProtocol)
+                let references = Set(try nestedContainer.decode([Reference].self))
+                let inherited = Set(try nestedContainer.decode([String].self))
+                self = .redundantProtocol(references: references, inherited: inherited)
+            case .redundantPublicAccessibility:
+                let modules = Set(try container.decode([String].self, forKey: .redundantPublicAccessibility))
+                self = .redundantPublicAccessibility(modules: modules)
+            default:
+                throw DecodingError.dataCorrupted(
+                    DecodingError.Context(codingPath: container.codingPath, debugDescription: "Unabled to decode enum.")
+                )
+            }
+        }
+        
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            
+            switch self {
+            case .unused:
+                try container.encode(true, forKey: .unused)
+            case .assignOnlyProperty:
+                try container.encode(true, forKey: .assignOnlyProperty)
+            case .redundantProtocol(let references, let inherited):
+                var nestedContainer = container.nestedUnkeyedContainer(forKey: .redundantProtocol)
+                try nestedContainer.encode(Array(references).sorted())
+                try nestedContainer.encode(Array(inherited).sorted())
+            case .redundantPublicAccessibility(let modules):
+                try container.encode(Array(modules).sorted(), forKey: .redundantPublicAccessibility)
+            }
+        }
     }
-
+    
     let declaration: Declaration
     let annotation: Annotation
 }

--- a/Sources/PeripheryKit/ScanResult.swift
+++ b/Sources/PeripheryKit/ScanResult.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-public struct ScanResult: Codable, Equatable, Hashable {
-    enum Annotation: Codable, Equatable, Hashable {
+public struct ScanResult: Codable, Hashable {
+    enum Annotation: Codable, Hashable {
         case unused
         case assignOnlyProperty
         case redundantProtocol(references: Set<Reference>, inherited: Set<String>)

--- a/Sources/PeripheryKit/ScanResult.swift
+++ b/Sources/PeripheryKit/ScanResult.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-public struct ScanResult {
-    enum Annotation {
+public struct ScanResult: Codable, Equatable, Hashable {
+    enum Annotation: Codable, Equatable, Hashable {
         case unused
         case assignOnlyProperty
         case redundantProtocol(references: Set<Reference>, inherited: Set<String>)

--- a/Sources/Shared/Configuration.swift
+++ b/Sources/Shared/Configuration.swift
@@ -122,6 +122,12 @@ public final class Configuration {
     @Setting(key: "json_package_manifest_path", defaultValue: nil)
     public var jsonPackageManifestPath: String?
 
+    @Setting(key: "baseline", defaultValue: nil)
+    public var baseline: String?
+
+    @Setting(key: "writeBaseline", defaultValue: nil)
+    public var writeBaseline: String?
+
     // Non user facing.
     public var guidedSetup: Bool = false
     public var removalOutputBasePath: FilePath?


### PR DESCRIPTION
WIP.

Addresses #710 

This is the equivalent of https://github.com/realm/SwiftLint/pull/5475

This adds two new arguments for the scan command: `--write-baseline <baseline>` to write a baseline file, and `--baseline <baseline>` to specify a baseline to use while scanning,

Should be functional, but periphery does not give consistent results for me since 2.18.0, which is problematic - see #731 

Straight port from the SwiftLint version - style is considerably different to typical periphery code style
Currently no unit tests
No way to view or compare baselines (potentially a nice to have).
