### PR TITLE
Xcode plugin support

### DIFF
--- a/Sources/Frontend/Commands/ScanCommand.swift
+++ b/Sources/Frontend/Commands/ScanCommand.swift
@@ -99,6 +99,9 @@ struct ScanCommand: FrontendCommand {
     @Flag(help: "Skip the project build step")
     var skipBuild: Bool = defaultConfiguration.$skipBuild.defaultValue
 
+    @Flag(help: "Skip schemes validation")
+    var skipSchemesValidation: Bool = defaultConfiguration.$skipSchemesValidation.defaultValue
+
     @Flag(help: "Output result paths relative to the current directory")
     var relativeResults: Bool = defaultConfiguration.$relativeResults.defaultValue
 
@@ -161,6 +164,7 @@ struct ScanCommand: FrontendCommand {
         configuration.apply(\.$strict, strict)
         configuration.apply(\.$indexStorePath, indexStorePath)
         configuration.apply(\.$skipBuild, skipBuild)
+        configuration.apply(\.$skipSchemesValidation, skipSchemesValidation)
         configuration.apply(\.$cleanBuild, cleanBuild)
         configuration.apply(\.$buildArguments, buildArguments)
         configuration.apply(\.$relativeResults, relativeResults)

--- a/Sources/Shared/Configuration.swift
+++ b/Sources/Shared/Configuration.swift
@@ -104,6 +104,9 @@ public final class Configuration {
     @Setting(key: "skip_build", defaultValue: false)
     public var skipBuild: Bool
 
+    @Setting(key: "skip_schemes_validation", defaultValue: false)
+    public var skipSchemesValidation: Bool
+
     @Setting(key: "clean_build", defaultValue: false)
     public var cleanBuild: Bool
 
@@ -239,6 +242,10 @@ public final class Configuration {
             config[$skipBuild.key] = skipBuild
         }
 
+        if $skipSchemesValidation.hasNonDefaultValue {
+            config[$skipSchemesValidation.key] = skipSchemesValidation
+        }
+
         if $cleanBuild.hasNonDefaultValue {
             config[$cleanBuild.key] = cleanBuild
         }
@@ -336,6 +343,8 @@ public final class Configuration {
                 $indexStorePath.assign(value)
             case $skipBuild.key:
                 $skipBuild.assign(value)
+            case $skipSchemesValidation.key:
+                $skipSchemesValidation.assign(value)
             case $cleanBuild.key:
                 $cleanBuild.assign(value)
             case $buildArguments.key:
@@ -382,6 +391,7 @@ public final class Configuration {
         $strict.reset()
         $indexStorePath.reset()
         $skipBuild.reset()
+        $skipSchemesValidation.reset()
         $cleanBuild.reset()
         $buildArguments.reset()
         $relativeResults.reset()

--- a/Sources/XcodeSupport/XcodeProjectDriver.swift
+++ b/Sources/XcodeSupport/XcodeProjectDriver.swift
@@ -46,12 +46,18 @@ public final class XcodeProjectDriver {
             throw PeripheryError.invalidTargets(names: invalidTargetNames.sorted(), project: project.path.lastComponent?.string ?? "")
         }
 
-        // Ensure schemes exist within the project
-        let schemes = try project.schemes().filter { configuration.schemes.contains($0) }
-        let validSchemeNames = schemes.mapSet { $0 }
+        let schemes: Set<String>
 
-        if let scheme = Set(configuration.schemes).subtracting(validSchemeNames).first {
-            throw PeripheryError.invalidScheme(name: scheme, project: project.path.lastComponent?.string ?? "")
+        if configuration.skipSchemesValidation {
+            schemes = Set(configuration.schemes)
+        } else {
+            // Ensure schemes exist within the project
+            schemes = try project.schemes().filter { configuration.schemes.contains($0) }
+            let validSchemeNames = schemes.mapSet { $0 }
+
+            if let scheme = Set(configuration.schemes).subtracting(validSchemeNames).first {
+                throw PeripheryError.invalidScheme(name: scheme, project: project.path.lastComponent?.string ?? "")
+            }
         }
 
         return self.init(


### PR DESCRIPTION
Hi! This is another PR for using Periphery in Swift Package plugins. This time I added support for using plugins in Xcode projects. The plugin's sandbox limitation prevents to execute `xcodebuild -project path-to.xcodeproj -list -json` so I added a new flag `--skip-schemes-validation`, schemes will be provided as is.

I have added support for Xcode plugins (`XcodeCommandPlugin/XcodeBuildToolPlugin`) [here](https://github.com/rock88/PeripheryPlugin):

https://github.com/peripheryapp/periphery/assets/323908/699c4c4d-696d-449e-9132-e611f789a0f2

