### PR TITLE
Fix linked space in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@
 
 <p align="center">
 <a href="https://github.com/peripheryapp/periphery/releases/latest">
-  <img src="https://img.shields.io/github/release/peripheryapp/periphery.svg?color=008DFF" />
-</a>
+<img src="https://img.shields.io/github/release/peripheryapp/periphery.svg?color=008DFF"/></a>
 <img src="https://img.shields.io/badge/platform-macOS%20|%20Linux-008DFF">
 <a href="#sponsors-">
 <img src="https://img.shields.io/github/sponsors/peripheryapp?logo=githubsponsors&color=db61a2">


### PR DESCRIPTION
This is a minor change but since it was bothering me, I thought I'd fix it. There was an underlined (linked) space between the badges, and this fixes it.

| Before | After |
|--------|--------|
| <img width="166" alt="Screenshot 2024-05-21 at 10 40 43 AM" src="https://github.com/peripheryapp/periphery/assets/59564/abf209dc-dcdf-44b1-b741-fc404ef96fe0"> | <img width="166" alt="Screenshot 2024-05-21 at 10 41 11 AM" src="https://github.com/peripheryapp/periphery/assets/59564/524bdfd9-1649-4d5c-b544-32d406886fc6"> | 