### PR TITLE
Create formatter for GitHub Actions

### DIFF
--- a/Sources/PeripheryKit/Formatters/ActionsFormatter.swift
+++ b/Sources/PeripheryKit/Formatters/ActionsFormatter.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Shared
+import SystemPackage
+
+final class ActionsFormatter: OutputFormatter {
+    let configuration: Configuration
+    lazy var currentFilePath: FilePath = { .current }()
+
+    init(configuration: Configuration) {
+        self.configuration = configuration
+    }
+
+    func format(_ results: [ScanResult]) throws -> String {
+        guard results.count > 0 else { return "" }
+        guard configuration.relativeResults else { throw PeripheryError.usageError("`periphery scan` must be ran with `--relative-results` when using the actions formatter")}
+
+        return results.flatMap { result in
+            describe(result, colored: false).map { (location, description) in
+                prefix(for: location, result: result) + description
+            }
+        }
+        .joined(separator: "\n")
+    }
+
+    // MARK: - Private
+
+    private func prefix(for location: SourceLocation, result: ScanResult) -> String {
+        let path = outputPath(location)
+        let lineNum = String(location.line)
+        let column = location.column
+        let title = describe(result.annotation)
+
+        return "::warning file=\(path),line=\(lineNum),col=\(column),title=\(title)::"
+    }
+}

--- a/Sources/PeripheryKit/Formatters/OutputFormatter.swift
+++ b/Sources/PeripheryKit/Formatters/OutputFormatter.swift
@@ -105,6 +105,8 @@ public extension OutputFormat {
             return JsonFormatter.self
         case .checkstyle:
             return CheckstyleFormatter.self
+        case .actions:
+            return ActionsFormatter.self
         }
     }
 }

--- a/Sources/Shared/OutputFormat.swift
+++ b/Sources/Shared/OutputFormat.swift
@@ -6,6 +6,7 @@ public enum OutputFormat: String, CaseIterable {
     case json
     case checkstyle
     case codeclimate
+    case actions
 
     public static let `default` = OutputFormat.xcode
 


### PR DESCRIPTION
This pull request adds a formatter for use with GitHub Actions.

The output of this formatter is meant to work as an actions annotation, as per the [Actions Docs](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-warning-message).

For example, if I had a file within my `Utilities` module that had an unused function, it would be output this way:

```
::warning file=Modules/Utilities/Sources/Utility/Sequence+Contains.swift,line=13,col=10,title=unused::Function 'containsNone(_:)' is unused
```

_____

**Usage**

```sh
$ periphery scan --relative-results --format actions
```

> [!NOTE]
> Failure to specify `--relative-results` will result in a usage error being thrown instructing the user to use `--relative-results`. GitHub Actions specifically wants relative paths.

When used in CI, we get results directly on pull requests. 

<img width="891" alt="Screenshot 2024-05-22 at 12 14 28 PM" src="https://github.com/peripheryapp/periphery/assets/3388381/48b76518-19fe-461e-adb2-f259c2d3840a">

___ 

New class and methods:

* [`Sources/PeripheryKit/Formatters/ActionsFormatter.swift`](diffhunk://#diff-bcd7fd5120e3b0390eb98fd4bfb10e07453afadd5e61997bb01343a088652f9fR1-R35): Introduced a new `ActionsFormatter` class with a `format` method to format scan results. This class requires the `relativeResults` configuration to be set, otherwise, it throws a `PeripheryError.usageError`.

Enum extension:

* [`Sources/Shared/OutputFormat.swift`](diffhunk://#diff-420da8f00e14ec100efa47f6c32d9d45cbba3aeee8052a8ae5a8f8fbb3d30053R9): Extended the `OutputFormat` enum to include a new case `actions`.
* [`Sources/PeripheryKit/Formatters/OutputFormatter.swift`](diffhunk://#diff-14e93992a57154ec7b785500f34b03cc88395366e9f969cf4d2dec68cfc38bc8R108-R109): Updated the `OutputFormat` extension to return `ActionsFormatter.self` when the `actions` case is selected.