### PR TITLE
Make .release dir before copying info.json into that dir

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -35,6 +35,9 @@ printf "Got it: $version\n"
 
 confirm "\nContinue?"
 
+rm -rf .release
+mkdir .release
+
 cat scripts/Version.swift.template | sed s/__VERSION__/${version}/ > Sources/Frontend/Version.swift
 cat scripts/Periphery.podspec.template | sed s/__VERSION__/${version}/ > Periphery.podspec
 cat scripts/artifactbundle_info.json.template | sed s/__VERSION__/${version}/ > .release/info.json
@@ -45,8 +48,6 @@ confirm "Continue?"
 bin_path=$(make show_bin_path)
 rm -rf "$bin_path"
 make build_release
-rm -rf .release
-mkdir .release
 cp "$bin_path" .release/
 cp LICENSE.md .release/
 cp scripts/release_notes.md.template .release/release_notes.md


### PR DESCRIPTION
Hi! Since version 2.20.0, periphery.artifactbundle.zip does not contain the info.json file because the release script will delete this dir later.
As a fix, we can remove/make .release dir before using.

<img width="532" alt="Screenshot 2024-06-24 at 13 31 30" src="https://github.com/peripheryapp/periphery/assets/323908/3ea772c5-a4df-4afa-a6df-3333ede44b0e">

<img width="536" alt="Screenshot 2024-06-24 at 13 32 44" src="https://github.com/peripheryapp/periphery/assets/323908/a8b9e1e0-25c7-44df-8fb4-9609e21b425b">
