### PR TITLE
Update XcodeProj minimal version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ var dependencies: [Package.Dependency] = [
 dependencies.append(
     .package(
         url: "https://github.com/tuist/xcodeproj",
-        from: "8.0.0"
+        from: "8.16.0"
     )
 )
 #endif


### PR DESCRIPTION
If you follow the contents of Package.swift, the version of XcodeProj may be less than 8.16.0 depending on the environment in which Periphery is installed. However, the XcodeProject class uses the `localPackages` property introduced after 8.16.0 of XcodeProj, resulting in a build error.
This Pull Request updates the minimum version of XcodeProj so that this error does not occur.

One concern is that the version of XcodeProj on which XcodeGen depends is fixed at 8.13.0. Projects that use it at the same time are more likely to fail to resolve dependencies.

https://github.com/peripheryapp/periphery/blob/3f769042ec88229356bfeef5674582217f0a5a59/Sources/XcodeSupport/XcodeProject.swift#L75

https://github.com/tuist/XcodeProj/blob/447c159b0c5fb047a024fd8d942d4a76cf47dde0/Sources/XcodeProj/Objects/Project/PBXProject.swift#L155