### PR TITLE
Embedded Swift Packages Target Recognize Issue

### DIFF
--- a/Sources/XcodeSupport/XcodeProjectDriver.swift
+++ b/Sources/XcodeSupport/XcodeProjectDriver.swift
@@ -31,12 +31,18 @@ public final class XcodeProjectDriver {
             } else {
                 let parts = targetName.split(separator: ".", maxSplits: 1)
 
-                if let packageName = parts.first,
-                   let targetName = parts.last,
-                   let package = project.packageTargets.keys.first(where: { $0.name == packageName }),
-                   let target = project.packageTargets[package]?.first(where: { $0.name == targetName })
-                {
+                guard let packageName = parts.first,
+                      let packageTargetName = parts.last,
+                      let package = project.packageTargets.keys.first(where: { $0.name == packageName })
+                else {
+                    invalidTargetNames.append(targetName)
+                    continue
+                }
+                
+                if let target = project.packageTargets[package]?.first(where: { $0.name == packageTargetName }) {
                     packageTargets[package, default: []].insert(target)
+                } else if let subTarget = package.targets.first(where: { $0.name == packageTargetName }) {
+                    packageTargets[package, default: []].insert(subTarget)
                 } else {
                     invalidTargetNames.append(targetName)
                 }

--- a/Sources/XcodeSupport/XcodeProjectSetupGuide.swift
+++ b/Sources/XcodeSupport/XcodeProjectSetupGuide.swift
@@ -36,7 +36,7 @@ public final class XcodeProjectSetupGuide: SetupGuideHelpers, ProjectSetupGuide 
 
             var targets = project.targets.map { $0.name }
             targets += project.packageTargets.flatMap { (package, targets) in
-                targets.map { "\(package.name).\($0.name)" }
+                package.targets.map { "\(package.name).\($0.name)" }
             }
             targets = targets.sorted()
 


### PR DESCRIPTION
Hello,

When the scan --setup command is run on SPM packages, all targets are visible.
<img width="495" alt="Screenshot 2024-07-16 at 16 12 38" src="https://github.com/user-attachments/assets/fc42ec71-62f4-4236-ad87-32ccccf37d96">

When the scan --setup command is run with the xcode workspace parameter, only the package names are visible, but the targets are not.
<img width="490" alt="Screenshot 2024-07-16 at 16 14 35" src="https://github.com/user-attachments/assets/5f8749b9-5fa0-42e8-9844-9afdb77bdde8">

With this pull request, all targets in the SPM packages in Workspace can be used.
<img width="703" alt="Screenshot 2024-07-16 at 16 23 53" src="https://github.com/user-attachments/assets/3d4e63f0-330f-4db5-b782-83a0e2c56ac8">

