### PR TITLE
Change the type of path in Configuration setter

### DIFF
--- a/Sources/Shared/Configuration.swift
+++ b/Sources/Shared/Configuration.swift
@@ -294,8 +294,8 @@ protocol AbstractSetting {
 }
 
 private let filePathSetter: (Any) -> FilePath? = { value in
-    if let value = value as? String {
-        return FilePath(value)
+    if let value = value as? FilePath {
+        return value
     }
 
     return nil


### PR DESCRIPTION
The type of path parameter in ScanCommand was changed from String to FilePath, but setter in configuration wasn't, because of that it is impossible to load project via  --path argument