### PR TITLE
feat: Support filter by source branch

### DIFF
--- a/Sources/Configuration/Configuration.swift
+++ b/Sources/Configuration/Configuration.swift
@@ -115,6 +115,9 @@ public final class Configuration {
 
     @Setting(key: "json_package_manifest_path", defaultValue: nil, setter: filePathSetter)
     public var jsonPackageManifestPath: FilePath?
+    
+    @Setting(key: "source_branch", defaultValue: nil)
+    public var sourceBranch: String?
 
     @Setting(key: "baseline", defaultValue: nil, setter: filePathSetter)
     public var baseline: FilePath?

--- a/Sources/Extensions/FilePath+Extension.swift
+++ b/Sources/Extensions/FilePath+Extension.swift
@@ -33,6 +33,16 @@ public extension FilePath {
         try closure()
         _ = fileManager.changeCurrentDirectoryPath(previous.string)
     }
+    
+    @inlinable
+    func chdir<T>(closure: () throws -> T) rethrows -> T {
+        let previous = Self.current
+        _ = fileManager.changeCurrentDirectoryPath(string)
+        defer {
+            _ = fileManager.changeCurrentDirectoryPath(previous.string)
+        }
+        return try closure()
+    }
 
     @inlinable
     func relativeTo(_ relativePath: FilePath) -> FilePath {

--- a/Sources/Frontend/Commands/ScanCommand.swift
+++ b/Sources/Frontend/Commands/ScanCommand.swift
@@ -119,6 +119,9 @@ struct ScanCommand: FrontendCommand {
 
     @Option(help: "JSON package manifest path (obtained using `swift package describe --type json` or manually)")
     var jsonPackageManifestPath: FilePath?
+    
+    @Option(help: "The target branch to compare against. Use to filter results to only those that are new or changed in the target branch. (Default is non-filter)")
+    var sourceBranch: String?
 
     @Option(help: "Baseline file path used to filter results")
     var baseline: FilePath?
@@ -182,6 +185,7 @@ struct ScanCommand: FrontendCommand {
         configuration.apply(\.$retainCodableProperties, retainCodableProperties)
         configuration.apply(\.$retainEncodableProperties, retainEncodableProperties)
         configuration.apply(\.$jsonPackageManifestPath, jsonPackageManifestPath)
+        configuration.apply(\.$sourceBranch, sourceBranch)
         configuration.apply(\.$baseline, baseline)
         configuration.apply(\.$writeBaseline, writeBaseline)
         configuration.apply(\.$genericProjectConfig, genericProjectConfig)
@@ -216,7 +220,13 @@ struct ScanCommand: FrontendCommand {
             baseline = try JSONDecoder().decode(Baseline.self, from: data)
         }
 
-        let filteredResults = try OutputDeclarationFilter(configuration: configuration, logger: logger).filter(results, with: baseline)
+        let filteredResults = OutputDeclarationFilter(
+            configuration: configuration,
+            baseline: baseline,
+            shell: shell,
+            logger: logger
+        )
+            .filter(results)
 
         if let baselinePath = configuration.writeBaseline {
             let usrs = filteredResults

--- a/Sources/PeripheryKit/Results/Filters/BaselineFilter.swift
+++ b/Sources/PeripheryKit/Results/Filters/BaselineFilter.swift
@@ -1,21 +1,26 @@
 import Configuration
-import FilenameMatcher
 import Foundation
 import Logger
-import SystemPackage
 
-public final class OutputDeclarationFilter {
+struct BaselineFilter: OutputFilterable {
     private let configuration: Configuration
+    private let baseline: Baseline?
     private let logger: Logger
     private let contextualLogger: ContextualLogger
-
-    public required init(configuration: Configuration, logger: Logger) {
+    
+    init(
+        configuration: Configuration,
+        baseline: Baseline?,
+        logger: Logger,
+        contextualLogger: ContextualLogger
+    ) {
         self.configuration = configuration
+        self.baseline = baseline
         self.logger = logger
-        contextualLogger = logger.contextualized(with: "report:filter")
+        self.contextualLogger = contextualLogger
     }
-
-    public func filter(_ declarations: [ScanResult], with baseline: Baseline?) throws -> [ScanResult] {
+    
+    func filter(_ declarations: [ScanResult]) -> [ScanResult] {
         var declarations = declarations
 
         if let baseline {

--- a/Sources/PeripheryKit/Results/Filters/OutputDeclarationFilter.swift
+++ b/Sources/PeripheryKit/Results/Filters/OutputDeclarationFilter.swift
@@ -1,0 +1,44 @@
+import Configuration
+import FilenameMatcher
+import Foundation
+import Logger
+import SystemPackage
+import Shared
+
+public final class OutputDeclarationFilter {
+    private let configuration: Configuration
+    private let baseline: Baseline?
+    private let logger: Logger
+    private let shell: Shell
+    private let diffProviderFactory: DiffProviderFactoryProtocol.Type
+
+    public required init(
+        configuration: Configuration,
+        baseline: Baseline?,
+        shell: Shell,
+        logger: Logger,
+        diffProviderFactory: DiffProviderFactoryProtocol.Type = DiffProviderFactory.self
+    ) {
+        self.configuration = configuration
+        self.baseline = baseline
+        self.logger = logger
+        self.shell = shell
+        self.diffProviderFactory = diffProviderFactory
+    }
+
+    public func filter(_ declarations: [ScanResult]) -> [ScanResult] {
+        let diffProviders = diffProviderFactory.makeDiffProvider(
+            configuration: configuration,
+            shell: shell,
+            baseline: baseline,
+            logger: logger
+        )
+        
+        var filteredDeclarations = declarations
+        for diffProvider in diffProviders {
+            filteredDeclarations = diffProvider.filter(filteredDeclarations)
+        }
+        
+        return filteredDeclarations
+    }
+}

--- a/Sources/PeripheryKit/Results/Filters/OutputFilterable.swift
+++ b/Sources/PeripheryKit/Results/Filters/OutputFilterable.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Logger
+import Configuration
+import Shared
+
+public protocol OutputFilterable {
+    func filter(_ declarations: [ScanResult]) -> [ScanResult]
+}
+
+public protocol DiffProviderFactoryProtocol {
+    static func makeDiffProvider(
+        configuration: Configuration,
+        shell: Shell,
+        baseline: Baseline?,
+        logger: Logger
+    ) -> [OutputFilterable]
+}
+
+public enum DiffProviderFactory: DiffProviderFactoryProtocol {
+    public static func makeDiffProvider(
+        configuration: Configuration,
+        shell: Shell,
+        baseline: Baseline?,
+        logger: Logger
+    ) -> [OutputFilterable] {
+        let contextualLogger = logger.contextualized(with: "report:filter")
+        var diffProviders: [OutputFilterable] = []
+        
+        if let sourceBranch = configuration.sourceBranch {
+            diffProviders.append(SourceBranchFilter(
+                sourceBranch: sourceBranch,
+                shell: shell,
+                contextualLogger: contextualLogger
+            ))
+        }
+        
+        diffProviders.append(
+            BaselineFilter(
+                configuration: configuration,
+                baseline: baseline,
+                logger: logger,
+                contextualLogger: contextualLogger
+            )
+        )
+        
+        return diffProviders
+    }
+}

--- a/Sources/PeripheryKit/Results/Filters/SourceBranchFilter.swift
+++ b/Sources/PeripheryKit/Results/Filters/SourceBranchFilter.swift
@@ -1,0 +1,77 @@
+import Shared
+import Logger
+
+struct SourceBranchFilter: OutputFilterable {
+    let shell: Shell
+    let sourceBranch: String
+    let contextualLogger: ContextualLogger
+
+    public init(
+        sourceBranch: String,
+        shell: Shell,
+        contextualLogger: ContextualLogger
+    ) {
+        self.sourceBranch = sourceBranch
+        self.shell = shell
+        self.contextualLogger = contextualLogger
+    }
+
+    /// Gives you the diff for a single file
+    ///
+    /// - Parameter file: The file path
+    /// - Returns: File diff or error
+    private func diff(forFile file: String) -> Result<FileDiff, Error> {
+        let parser = DiffParser()
+        let diff = Result { try shell.exec(["git", "diff", sourceBranch, "--", file]) }
+        return diff.flatMap {
+            let diff = parser.parse($0)
+
+            if let fileDiff = diff.first {
+                return .success(fileDiff)
+            } else {
+                contextualLogger.debug("Git diff for \(file) is invalid.")
+                return .failure(DiffError.invalidDiff)
+            }
+        }
+    }
+    
+    private func diff(violation: ScanResult) -> Bool {
+        do {
+            let changes: FileDiff.Changes = try diff(forFile: violation.declaration.location.file.path.string)
+                .get()
+                .changes
+            
+            switch changes {
+            case .created:
+                return true
+            case .deleted:
+                return false
+            case let .modified(hunks):
+                return hunks.contains { hunk in
+                    let newLineRanges = hunk.newLineStart ..< hunk.newLineStart + hunk.newLineSpan
+                    return newLineRanges.contains(violation.declaration.location.line)
+                }
+            case .renamed:
+                return false
+            }
+        } catch {
+            return false
+        }
+    }
+    
+    func filter(_ declarations: [ScanResult]) -> [ScanResult] {
+        do {
+            try shell.exec(["git", "status"])
+            return declarations.filter(diff)
+        } catch {
+            contextualLogger.debug("Git do not exist in the current directory. Skipping filtering.")
+            return declarations
+        }
+    }
+}
+
+extension SourceBranchFilter {
+    enum DiffError: Error, Equatable {
+        case invalidDiff
+    }
+}

--- a/Sources/PeripheryKit/Results/GitDiff.swift
+++ b/Sources/PeripheryKit/Results/GitDiff.swift
@@ -1,0 +1,190 @@
+import Foundation
+
+// https://github.com/danger/swift/blob/master/Sources/Danger/GitDiff.swift
+
+public struct FileDiff: Equatable, CustomStringConvertible {
+    private let parsedHeader: ParsedHeader
+    private let hunks: [FileDiff.Hunk]
+
+    init(parsedHeader: ParsedHeader, hunks: [FileDiff.Hunk]) {
+        self.parsedHeader = parsedHeader
+        self.hunks = hunks
+    }
+
+    public var filePath: String {
+        parsedHeader.filePath
+    }
+
+    public var changes: Changes {
+        switch parsedHeader.change {
+        case .created:
+            return .created(addedLines: hunks.flatMap { hunk in hunk.lines.map(\.text) })
+        case .deleted:
+            return .deleted(deletedLines: hunks.flatMap { hunk in hunk.lines.map(\.text) })
+        case .modified:
+            return .modified(hunks: hunks)
+        case let .renamed(oldPath: oldPath):
+            return .renamed(oldPath: oldPath, hunks: hunks)
+        }
+    }
+
+    public var description: String {
+        hunks.map(\.description).joined(separator: "\n")
+    }
+}
+
+extension FileDiff {
+    struct ParsedHeader: Equatable {
+        let filePath: String
+        let change: ChangeType
+    }
+}
+
+extension FileDiff.ParsedHeader {
+    enum ChangeType: Equatable {
+        case created
+        case deleted
+        case renamed(oldPath: String)
+        case modified
+    }
+}
+
+public extension FileDiff {
+    enum Changes: Equatable {
+        case created(addedLines: [String])
+        case deleted(deletedLines: [String])
+        case modified(hunks: [Hunk])
+        case renamed(oldPath: String, hunks: [Hunk])
+    }
+
+    struct Hunk: Equatable, CustomStringConvertible {
+        public let oldLineStart: Int
+        public let oldLineSpan: Int
+        public let newLineStart: Int
+        public let newLineSpan: Int
+        public let lines: [Line]
+        public var description: String {
+            "@@ -\(oldLineStart),\(oldLineSpan) +\(newLineStart),\(newLineSpan) @@" +
+                lines.map(\.description).joined(separator: "\n")
+        }
+    }
+
+    struct Line: Equatable, CustomStringConvertible {
+        let text: String
+        let changeType: ChangeType
+        public var description: String {
+            switch changeType {
+            case .added:
+                return "+" + text
+            case .removed:
+                return "-" + text
+            case .unchanged:
+                return " " + text
+            }
+        }
+    }
+}
+
+extension FileDiff.Line {
+    enum ChangeType: Equatable {
+        case added
+        case removed
+        case unchanged
+    }
+}
+
+extension StringProtocol {
+    func deletingPrefix(_ prefix: String) -> String {
+        guard hasPrefix(prefix) else { return String(self) }
+        return String(dropFirst(prefix.count))
+    }
+}
+
+struct DiffParser {
+    func parse(_ diff: String) -> [FileDiff] {
+        diff.components(separatedBy: "diff --git ").compactMap { fileDiff in
+            let headerAndHunks = fileDiff.components(separatedBy: "@@")
+            guard let header = headerAndHunks.first,
+                  !header.isEmpty
+            else {
+                return nil
+            }
+
+            return FileDiff(parsedHeader: parseHeader(header), hunks: parseHunks(Array(headerAndHunks.dropFirst())))
+        }
+    }
+
+    private func parseHeader(_ header: String) -> FileDiff.ParsedHeader {
+        let lines = header.components(separatedBy: "\n")
+
+        let filePath = lines.first?.split(separator: " ").first(where: { $0.starts(with: "b/") })?
+            .deletingPrefix("b/") ?? ""
+
+        let change: FileDiff.ParsedHeader.ChangeType
+
+        if lines.contains(where: { $0.hasPrefix("deleted file mode ") }) {
+            change = .deleted
+        } else if lines.contains(where: { $0.hasPrefix("new file mode") }) {
+            change = .created
+        } else if let modifiedLineIndex = lines.firstIndex(where: { $0.hasPrefix("rename from ") }) {
+            change = .renamed(oldPath: lines[modifiedLineIndex].deletingPrefix("rename from "))
+        } else {
+            change = .modified
+        }
+
+        return FileDiff.ParsedHeader(filePath: filePath, change: change)
+    }
+
+    private func parseHunks(_ hunks: [String]) -> [FileDiff.Hunk] {
+        (0 ..< hunks.count / 2).compactMap { index -> FileDiff.Hunk? in
+            let changesSpan = hunks[index * 2]
+            let changes = hunks[index * 2 + 1]
+            let lines = changes.components(separatedBy: "\n").dropFirst().filter { !$0.isEmpty }.map(parseLine)
+            let parsedChanges = parseChangesSpan(changesSpan)
+
+            return FileDiff.Hunk(oldLineStart: parsedChanges.oldLineStart,
+                                 oldLineSpan: parsedChanges.oldLineSpan,
+                                 newLineStart: parsedChanges.newLineStart,
+                                 newLineSpan: parsedChanges.newLineSpan,
+                                 lines: lines)
+        }
+    }
+
+    private func parseLine(_ line: String) -> FileDiff.Line {
+        let text = String(line.dropFirst())
+        if line.hasPrefix("+") {
+            return FileDiff.Line(text: String(line.dropFirst()), changeType: .added)
+        } else if line.hasPrefix("-") {
+            return FileDiff.Line(text: String(line.dropFirst()), changeType: .removed)
+        } else {
+            return FileDiff.Line(text: text, changeType: .unchanged)
+        }
+    }
+
+    private func parseChangesSpan(_ changesSpan: String) -> HunkSpan {
+        let dividedSpan = changesSpan.split(separator: " ").map { $0.dropFirst().components(separatedBy: ",") }
+        if dividedSpan.count == 2,
+           dividedSpan[0].count == 2,
+           dividedSpan[1].count == 2,
+           let oldLineStart = Int(dividedSpan[0][0]),
+           let oldLineSpan = Int(dividedSpan[0][1]),
+           let newLineStart = Int(dividedSpan[1][0]),
+           let newLineSpan = Int(dividedSpan[1][1]) {
+            return HunkSpan(oldLineStart: oldLineStart,
+                            oldLineSpan: oldLineSpan,
+                            newLineStart: newLineStart,
+                            newLineSpan: newLineSpan)
+        } else {
+            return HunkSpan(oldLineStart: 0, oldLineSpan: 0, newLineStart: 0, newLineSpan: 0)
+        }
+    }
+}
+
+private extension DiffParser {
+    struct HunkSpan {
+        let oldLineStart: Int
+        let oldLineSpan: Int
+        let newLineStart: Int
+        let newLineSpan: Int
+    }
+}


### PR DESCRIPTION
## Description

Currently, we don't support filter results only on changed/added files. This PR adds logic to support that feature.

## How it works?

1. Using periphery scan to get the outputs.
2. Use 'git diff $sourceBranch --path $filePath' to get all the changes in that file. (filePath comes from the output.declaration.location.path)
3. Compare the output.declaration.location.line with the newLineStart and newLineSpan from the diff. If it matches, then it's a new/changed line.

## Notes

This is a propose idea and solution. I haven't updated the tests. If you feel the feature and the solution is okay, I will update the tests. 
Please take a look and let me know if you have any suggestions. Thank you