### PR TITLE
Updates xcodeproj version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/xcodeproj",
       "state" : {
-        "revision" : "babd2491ea34777bec9d33381a60cd782559b4b3",
-        "version" : "8.24.1"
+        "revision" : "2c495492fb6e01de5e718a0fd94e0fb28a307d4d",
+        "version" : "8.24.7"
       }
     },
     {


### PR DESCRIPTION
Updates xcodeproj to v8.24.7 in order to fix Xcode16 error.

See https://github.com/peripheryapp/periphery/issues/813