### PR TITLE
Mark prefix, postfix, and infix operators as function results

### DIFF
--- a/Sources/SourceGraph/Elements/Declaration.swift
+++ b/Sources/SourceGraph/Elements/Declaration.swift
@@ -198,7 +198,7 @@ public final class Declaration {
                 "initializer"
             case .extension, .extensionEnum, .extensionClass, .extensionStruct, .extensionProtocol:
                 "extension"
-            case .functionMethodClass, .functionMethodStatic, .functionMethodInstance, .functionFree, .functionOperator, .functionSubscript:
+            case .functionMethodClass, .functionMethodStatic, .functionMethodInstance, .functionFree, .functionOperator, .functionOperatorInfix, .functionOperatorPostfix, .functionOperatorPrefix, .functionSubscript:
                 "function"
             case .varStatic, .varInstance, .varClass, .varGlobal, .varLocal:
                 "property"


### PR DESCRIPTION
Diagnoses an unused prefix, postfix, or infix operator as a function type:

```diff
- /some/path/Foo.swift:159:31: warning: '+=(_:_:)' is unused
+ /some/path/Foo.swift:159:31: warning: Function '+=(_:_:)' is unused
```

Fixes https://github.com/peripheryapp/periphery/issues/877.