### PR TITLE
Fix warnings in Xcode 16.2

### DIFF
--- a/Sources/Configuration/Configuration.swift
+++ b/Sources/Configuration/Configuration.swift
@@ -329,13 +329,13 @@ extension Setting where Value == [String] {
 
 // MARK: - Yaml Encoding
 
-extension OutputFormat: ScalarRepresentable {
+extension OutputFormat: Yams.ScalarRepresentable {
     public func represented() -> Node.Scalar {
         rawValue.represented()
     }
 }
 
-extension FilePath: ScalarRepresentable {
+extension FilePath: Yams.ScalarRepresentable {
     public func represented() -> Node.Scalar {
         string.represented()
     }

--- a/Sources/Extensions/FilePath+Extension.swift
+++ b/Sources/Extensions/FilePath+Extension.swift
@@ -68,7 +68,7 @@ public extension FilePath {
     }
 }
 
-extension FilePath: Comparable {
+extension FilePath: Swift.Comparable {
     public static func < (lhs: FilePath, rhs: FilePath) -> Bool {
         lhs.lexicallyNormalized().string < rhs.lexicallyNormalized().string
     }

--- a/Sources/Frontend/Commands/ScanCommand.swift
+++ b/Sources/Frontend/Commands/ScanCommand.swift
@@ -264,7 +264,7 @@ struct ScanCommand: FrontendCommand {
 
 extension OutputFormat: ExpressibleByArgument {}
 
-extension FilePath: ExpressibleByArgument {
+extension FilePath: ArgumentParser.ExpressibleByArgument {
     public init?(argument: String) {
         self.init(argument)
     }

--- a/Sources/Shared/SetupGuide.swift
+++ b/Sources/Shared/SetupGuide.swift
@@ -52,7 +52,7 @@ open class SetupGuideHelpers {
     }
 
     public func select(multiple options: [String]) -> SetupSelection {
-        var helpMsg = " Delimit choices with a single space, e.g: 1 2 3"
+        let helpMsg = " Delimit choices with a single space, e.g: 1 2 3"
 
         display(options: options)
         print(colorize("?", .boldYellow) + helpMsg)


### PR DESCRIPTION
Fixes these warnings by fully qualifying the cross-module conformances:

```
Sources/Configuration/Configuration.swift:338:1 Extension declares a conformance of imported type 'FilePath' to imported protocols 'ScalarRepresentable', 'NodeRepresentable'; this will not behave correctly if the owners of 'SystemPackage' introduce this conformance in the future

Sources/Extensions/FilePath+Extension.swift:71:1 Extension declares a conformance of imported type 'FilePath' to imported protocol 'Comparable'; this will not behave correctly if the owners of 'SystemPackage' introduce this conformance in the future
```

Fixes this warning by making the variable immutable:

```
Sources/Shared/SetupGuide.swift:55:13 Variable 'helpMsg' was never mutated; consider changing to 'let' constant
```