### PR TITLE
Fixes issue where comment commands are ignored for import statements

### DIFF
--- a/Sources/SourceGraph/Elements/ImportStatement.swift
+++ b/Sources/SourceGraph/Elements/ImportStatement.swift
@@ -5,16 +5,19 @@ public struct ImportStatement {
     public let isTestable: Bool
     public let isExported: Bool
     public let location: Location
+    public let commentCommands: [CommentCommand]
 
     public init(
         module: String,
         isTestable: Bool,
         isExported: Bool,
-        location: Location
+        location: Location,
+        commentCommands: [CommentCommand]
     ) {
         self.module = module
         self.isTestable = isTestable
         self.isExported = isExported
         self.location = location
+        self.commentCommands = commentCommands
     }
 }

--- a/Sources/SourceGraph/Mutators/UnusedImportMarker.swift
+++ b/Sources/SourceGraph/Mutators/UnusedImportMarker.swift
@@ -47,9 +47,9 @@ final class UnusedImportMarker: SourceGraphMutator {
                 .filter {
                     // Exclude ignore commented imports
                     !$0.commentCommands.contains(.ignore) &&
-                    // Exclude exported/public imports because even though they may be unreferenced
-                    // in the current file, their exported symbols may be referenced in others.
-                    !$0.isExported &&
+                        // Exclude exported/public imports because even though they may be unreferenced
+                        // in the current file, their exported symbols may be referenced in others.
+                        !$0.isExported &&
                         // Consider modules that have been indexed as we need to see which modules
                         // they export.
                         graph.indexedModules.contains($0.module) &&

--- a/Sources/SourceGraph/Mutators/UnusedImportMarker.swift
+++ b/Sources/SourceGraph/Mutators/UnusedImportMarker.swift
@@ -45,6 +45,8 @@ final class UnusedImportMarker: SourceGraphMutator {
 
             let unreferencedImports = file.importStatements
                 .filter {
+                    // Exclude ignore commented imports
+                    !$0.commentCommands.contains(.ignore) &&
                     // Exclude exported/public imports because even though they may be unreferenced
                     // in the current file, their exported symbols may be referenced in others.
                     !$0.isExported &&

--- a/Sources/SyntaxAnalysis/ImportSyntaxVisitor.swift
+++ b/Sources/SyntaxAnalysis/ImportSyntaxVisitor.swift
@@ -26,7 +26,8 @@ public final class ImportSyntaxVisitor: PeripherySyntaxVisitor {
             module: module,
             isTestable: attributes.contains("testable"),
             isExported: attributes.contains("_exported") || node.modifiers.contains { $0.name.text == "public" },
-            location: location
+            location: location,
+            commentCommands: CommentCommand.parseCommands(in: node.leadingTrivia)
         )
         importStatements.append(statement)
     }

--- a/Tests/Fixtures/Package.swift
+++ b/Tests/Fixtures/Package.swift
@@ -6,6 +6,9 @@ var targets: [PackageDescription.Target] = [
         name: "ExternalModuleFixtures"
     ),
     .target(
+        name: "UnusedModuleFixtures"
+    ),
+    .target(
         name: "CrossModuleRetentionFixtures",
         dependencies: [
             .target(name: "CrossModuleRetentionSupportFixtures")
@@ -17,7 +20,8 @@ var targets: [PackageDescription.Target] = [
     .target(
         name: "RetentionFixtures",
         dependencies: [
-            .target(name: "ExternalModuleFixtures")
+            .target(name: "ExternalModuleFixtures"),
+            .target(name: "UnusedModuleFixtures")
         ]
     ),
     .target(

--- a/Tests/Fixtures/Sources/RetentionFixtures/testIgnoreComments.swift
+++ b/Tests/Fixtures/Sources/RetentionFixtures/testIgnoreComments.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UnusedModuleFixtures
 
 // periphery:ignore
 public class Fixture113 {

--- a/Tests/Fixtures/Sources/RetentionFixtures/testIgnoreComments.swift
+++ b/Tests/Fixtures/Sources/RetentionFixtures/testIgnoreComments.swift
@@ -1,4 +1,5 @@
 import Foundation
+// periphery:ignore
 import UnusedModuleFixtures
 
 // periphery:ignore

--- a/Tests/Fixtures/Sources/UnusedModuleFixtures/UnusedModuleDeclaration.swift
+++ b/Tests/Fixtures/Sources/UnusedModuleFixtures/UnusedModuleDeclaration.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+public struct UnusedStruct {}

--- a/Tests/PeripheryTests/RetentionTest.swift
+++ b/Tests/PeripheryTests/RetentionTest.swift
@@ -891,7 +891,7 @@ final class RetentionTest: FixtureSourceGraphTestCase {
         ]
 
         analyze(retainPublic: true, additionalFilesToIndex: additionalFilesToIndex) {
-            assertNotReferenced(.module("UnusedModuleFixtures"))
+            assertReferenced(.module("UnusedModuleFixtures"))
             assertReferenced(.class("Fixture113")) {
                 self.assertReferenced(.functionMethodInstance("someFunc(param:)")) {
                     self.assertReferenced(.varParameter("param"))

--- a/Tests/PeripheryTests/RetentionTest.swift
+++ b/Tests/PeripheryTests/RetentionTest.swift
@@ -887,7 +887,7 @@ final class RetentionTest: FixtureSourceGraphTestCase {
     func testIgnoreComments() {
         // ensure this external module is explicitly indexed so we can tell if it is unused
         let additionalFilesToIndex = [
-            FixturesProjectPath.appending("Sources/UnusedModuleFixtures/UnusedModuleDeclaration.swift")
+            FixturesProjectPath.appending("Sources/UnusedModuleFixtures/UnusedModuleDeclaration.swift"),
         ]
 
         analyze(retainPublic: true, additionalFilesToIndex: additionalFilesToIndex) {

--- a/Tests/PeripheryTests/RetentionTest.swift
+++ b/Tests/PeripheryTests/RetentionTest.swift
@@ -885,7 +885,13 @@ final class RetentionTest: FixtureSourceGraphTestCase {
     }
 
     func testIgnoreComments() {
-        analyze(retainPublic: true) {
+        // ensure this external module is explicitly indexed so we can tell if it is unused
+        let additionalFilesToIndex = [
+            FixturesProjectPath.appending("Sources/UnusedModuleFixtures/UnusedModuleDeclaration.swift")
+        ]
+
+        analyze(retainPublic: true, additionalFilesToIndex: additionalFilesToIndex) {
+            assertNotReferenced(.module("UnusedModuleFixtures"))
             assertReferenced(.class("Fixture113")) {
                 self.assertReferenced(.functionMethodInstance("someFunc(param:)")) {
                     self.assertReferenced(.varParameter("param"))

--- a/Tests/Shared/DeclarationDescription.swift
+++ b/Tests/Shared/DeclarationDescription.swift
@@ -74,6 +74,10 @@ struct DeclarationDescription: CustomStringConvertible {
         self.init(kind: .functionSubscript, name: name, line: line)
     }
 
+    static func module(_ name: String, line: Int? = nil) -> Self {
+        self.init(kind: .module, name: name, line: line)
+    }
+
     static func varStatic(_ name: String, line: Int? = nil) -> Self {
         self.init(kind: .varStatic, name: name, line: line)
     }

--- a/Tests/Shared/FixtureSourceGraphTestCase.swift
+++ b/Tests/Shared/FixtureSourceGraphTestCase.swift
@@ -15,6 +15,7 @@ class FixtureSourceGraphTestCase: SPMSourceGraphTestCase {
         retainObjcAccessible: Bool = false,
         retainObjcAnnotated: Bool = false,
         disableRedundantPublicAnalysis: Bool = false,
+        additionalFilesToIndex: [FilePath] = [],
         testBlock: () throws -> Void
     ) rethrows -> [ScanResult] {
         configuration.retainPublic = retainPublic
@@ -27,7 +28,7 @@ class FixtureSourceGraphTestCase: SPMSourceGraphTestCase {
             fatalError("\(testFixturePath.string) does not exist")
         }
 
-        Self.index(sourceFile: testFixturePath)
+        Self.index(sourceFiles: [testFixturePath] + additionalFilesToIndex)
         try testBlock()
         return Self.results
     }

--- a/Tests/Shared/SourceGraphTestCase.swift
+++ b/Tests/Shared/SourceGraphTestCase.swift
@@ -45,12 +45,12 @@ open class SourceGraphTestCase: XCTestCase {
         }
     }
 
-    static func index(sourceFile: FilePath? = nil) {
+    static func index(sourceFiles: [FilePath]? = nil) {
         var newPlan = plan!
 
-        if let sourceFile {
+        if let sourceFiles {
             newPlan = IndexPlan(
-                sourceFiles: plan.sourceFiles.filter { $0.key.path == sourceFile },
+                sourceFiles: plan.sourceFiles.filter { sourceFiles.contains($0.key.path) },
                 plistPaths: plan.plistPaths,
                 xibPaths: plan.xibPaths,
                 xcDataModelPaths: plan.xcDataModelPaths,


### PR DESCRIPTION
Fixes part of #863.  Previously this ignore comment had no effect:

```swift
// periphery:ignore
import SomeUnusedModule
```

This support is important to ignore false positives from https://github.com/peripheryapp/periphery/issues/805.