### PR TITLE
Add the ability to put comment commands on the same line as an import statement

### DIFF
--- a/Sources/SyntaxAnalysis/ImportSyntaxVisitor.swift
+++ b/Sources/SyntaxAnalysis/ImportSyntaxVisitor.swift
@@ -27,7 +27,7 @@ public final class ImportSyntaxVisitor: PeripherySyntaxVisitor {
             isTestable: attributes.contains("testable"),
             isExported: attributes.contains("_exported") || node.modifiers.contains { $0.name.text == "public" },
             location: location,
-            commentCommands: CommentCommand.parseCommands(in: node.leadingTrivia)
+            commentCommands: CommentCommand.parseCommands(in: node.leadingTrivia.merging(node.trailingTrivia))
         )
         importStatements.append(statement)
     }

--- a/Tests/Fixtures/Sources/DeclarationVisitorFixtures/ImportFixture.swift
+++ b/Tests/Fixtures/Sources/DeclarationVisitorFixtures/ImportFixture.swift
@@ -1,0 +1,4 @@
+import Foundation
+// periphery:ignore
+import CoreFoundation
+import Swift // periphery:ignore

--- a/Tests/PeripheryTests/Syntax/ImportVisitTest.swift
+++ b/Tests/PeripheryTests/Syntax/ImportVisitTest.swift
@@ -1,0 +1,39 @@
+import Foundation
+@testable import SourceGraph
+@testable import SyntaxAnalysis
+@testable import TestShared
+import XCTest
+
+final class ImportVisitTest: XCTestCase {
+    private var results: [ImportStatement]!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let multiplexingVisitor = try MultiplexingSyntaxVisitor(file: fixturePath)
+        let visitor = multiplexingVisitor.add(ImportSyntaxVisitor.self)
+        multiplexingVisitor.visit()
+        results = visitor.importStatements
+    }
+
+    override func tearDown() {
+        results = nil
+        super.tearDown()
+    }
+
+    func testCommentCommands() {
+        let expectedIgnored = ["CoreFoundation", "Swift"]
+        let actualIgnored = results.filter { $0.commentCommands.contains(.ignore) }.map(\.module)
+        XCTAssertEqual(actualIgnored, expectedIgnored, "Ignored modules did not match the expected set")
+
+        let actualUnignored = results.filter { !$0.commentCommands.contains(.ignore) }.map(\.module)
+        let expectedUnignored = ["Foundation"]
+        XCTAssertEqual(actualUnignored, expectedUnignored, "Unignored modules did not match the expected set")
+    }
+
+    // MARK: - Private
+
+    private var fixturePath: SourceFile {
+        let path = FixturesProjectPath.appending("Sources/DeclarationVisitorFixtures/ImportFixture.swift")
+        return SourceFile(path: path, modules: ["DeclarationVisitorFixtures"])
+    }
+}


### PR DESCRIPTION
Depends on https://github.com/peripheryapp/periphery/pull/880.  Adds the ability to put comment commands on the same line as an import statement so that these are equivalent:

```
// periphery:ignore
import CoreGraphics

import CoreGraphics // periphery:ignore
```