### PR TITLE
Adding Support for Xcode 16's New Project Format

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e9d8baa60dce80cafa8b76899eb69396fc9c18d78f46733d4e15bc12127a6bd0",
+  "originHash" : "564f682d7bdc21f92e080a8c7de90ea373fb3c339d2f29e5ab3e3b22f01e2897",
   "pins" : [
     {
       "identity" : "aexml",
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/xcodeproj",
       "state" : {
-        "revision" : "d3df4265b8383dd56dae4b01f817d30c22e7612c",
-        "version" : "8.25.0"
+        "revision" : "02bc2dd6224aa59147941d85fdc45a7677af62f6",
+        "version" : "8.27.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ var dependencies: [Package.Dependency] = [
     dependencies.append(
         .package(
             url: "https://github.com/tuist/xcodeproj",
-            from: "8.25.0"
+            from: "8.27.3"
         )
     )
 #endif


### PR DESCRIPTION
Resolves #862 

This PR adds support Xcode 16's `PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet` by updating [tuist/XcodeProj](https://github.com/tuist/XcodeProj) to the latest version.

