### PR TITLE
Modified folder structure of artifact bundle

### DIFF
--- a/.mise/tasks/release
+++ b/.mise/tasks/release
@@ -72,8 +72,15 @@ echo -e "\n${zip_filename} checksum:"
 sha256=$( shasum -a 256 ${zip_filename} | awk '{print $1}' )
 echo ${sha256}
 
+macos_artifact="periphery-${version}-macos"
+artifactbundle="periphery-${version}.artifactbundle"
 zip_artifactbundle="periphery-${version}.artifactbundle.zip"
-zip "${zip_artifactbundle}" periphery LICENSE.md info.json
+
+mkdir -p ${macos_artifact}/bin
+cp periphery ${macos_artifact}/bin
+mkdir ${artifactbundle}
+cp -R ${macos_artifact} LICENSE.md info.json ${artifactbundle}
+zip -r "${zip_artifactbundle}" periphery-${version}.artifactbundle
 codesign "${zip_artifactbundle}"
 
 echo -e "\n${zip_artifactbundle} checksum:"

--- a/.mise/tasks/scripts/artifactbundle_info.json.template
+++ b/.mise/tasks/scripts/artifactbundle_info.json.template
@@ -6,7 +6,7 @@
             "type": "executable",
             "variants": [
                 {
-                    "path": "periphery",
+                    "path": "periphery-__VERSION__-macos/bin/periphery",
                     "supportedTriples": ["x86_64-apple-macosx", "arm64-apple-macosx"]
                 }
             ]


### PR DESCRIPTION
## Describe your changes

I have modified the folder structure of the artifact bundle as in the [SE-0305](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0305-swiftpm-binary-target-improvements.md).

It has been modified as shown in the screenshot below.

<table>
  <thead>
    <tr>
      <td>Before (`$ tree tree periphery-3.0.1.artifactbundle`)</td>
      <td>After (`$ tree periphery-3.0.3.artifactbundle`)</td>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img src="https://github.com/user-attachments/assets/e20c1c24-03e9-46c0-95d4-f4fcff52cdde"/></td>
      <td><img src="https://github.com/user-attachments/assets/056626ba-e7d1-49ce-a6aa-b15a26701a31"/></td>
    </tr>
  </tbody>
</table>

This's not a big problem when using a standalone artifact bundle, but when using an artifact bundle managed tool (like [nest](https://github.com/mtj0928/nest)), it was necessary to align the folder structure.

## Issue ticket number and link

- None.
