### PR TITLE
Allow inline comment commands on most declarations

### DIFF
--- a/Sources/SyntaxAnalysis/DeclarationSyntaxVisitor.swift
+++ b/Sources/SyntaxAnalysis/DeclarationSyntaxVisitor.swift
@@ -43,7 +43,7 @@ public final class DeclarationSyntaxVisitor: PeripherySyntaxVisitor {
         parse(
             modifiers: node.modifiers,
             attributes: node.attributes,
-            trivia: node.leadingTrivia,
+            trivia: node.commentCommandTrivia,
             inheritanceClause: node.inheritanceClause,
             genericParameterClause: node.genericParameterClause,
             genericWhereClause: node.genericWhereClause,
@@ -56,7 +56,7 @@ public final class DeclarationSyntaxVisitor: PeripherySyntaxVisitor {
         parse(
             modifiers: node.modifiers,
             attributes: node.attributes,
-            trivia: node.leadingTrivia,
+            trivia: node.commentCommandTrivia,
             inheritanceClause: node.inheritanceClause,
             genericParameterClause: node.genericParameterClause,
             genericWhereClause: node.genericWhereClause,
@@ -69,7 +69,7 @@ public final class DeclarationSyntaxVisitor: PeripherySyntaxVisitor {
         parse(
             modifiers: node.modifiers,
             attributes: node.attributes,
-            trivia: node.leadingTrivia,
+            trivia: node.commentCommandTrivia,
             inheritanceClause: node.inheritanceClause,
             genericWhereClause: node.genericWhereClause,
             at: node.name.positionAfterSkippingLeadingTrivia
@@ -80,7 +80,7 @@ public final class DeclarationSyntaxVisitor: PeripherySyntaxVisitor {
         parse(
             modifiers: node.modifiers,
             attributes: node.attributes,
-            trivia: node.leadingTrivia,
+            trivia: node.commentCommandTrivia,
             inheritanceClause: node.inheritanceClause,
             genericParameterClause: node.genericParameterClause,
             genericWhereClause: node.genericWhereClause,
@@ -93,7 +93,7 @@ public final class DeclarationSyntaxVisitor: PeripherySyntaxVisitor {
         parse(
             modifiers: node.modifiers,
             attributes: node.attributes,
-            trivia: node.leadingTrivia,
+            trivia: node.commentCommandTrivia,
             inheritanceClause: node.inheritanceClause,
             genericParameterClause: node.genericParameterClause,
             genericWhereClause: node.genericWhereClause,
@@ -128,7 +128,7 @@ public final class DeclarationSyntaxVisitor: PeripherySyntaxVisitor {
         parse(
             modifiers: node.modifiers,
             attributes: node.attributes,
-            trivia: node.leadingTrivia,
+            trivia: node.commentCommandTrivia,
             inheritanceClause: node.inheritanceClause,
             genericWhereClause: node.genericWhereClause,
             consumeCapitalSelfFunctionCalls: true,
@@ -140,7 +140,7 @@ public final class DeclarationSyntaxVisitor: PeripherySyntaxVisitor {
         parse(
             modifiers: node.modifiers,
             attributes: node.attributes,
-            trivia: node.leadingTrivia,
+            trivia: node.commentCommandTrivia,
             parameterClause: node.signature.parameterClause,
             returnClause: node.signature.returnClause,
             genericParameterClause: node.genericParameterClause,
@@ -153,7 +153,7 @@ public final class DeclarationSyntaxVisitor: PeripherySyntaxVisitor {
         parse(
             modifiers: node.modifiers,
             attributes: node.attributes,
-            trivia: node.leadingTrivia,
+            trivia: node.commentCommandTrivia,
             parameterClause: node.signature.parameterClause,
             genericParameterClause: node.genericParameterClause,
             genericWhereClause: node.genericWhereClause,
@@ -165,7 +165,7 @@ public final class DeclarationSyntaxVisitor: PeripherySyntaxVisitor {
         parse(
             modifiers: node.modifiers,
             attributes: node.attributes,
-            trivia: node.leadingTrivia,
+            trivia: node.commentCommandTrivia,
             at: node.deinitKeyword.positionAfterSkippingLeadingTrivia
         )
     }
@@ -174,7 +174,7 @@ public final class DeclarationSyntaxVisitor: PeripherySyntaxVisitor {
         parse(
             modifiers: node.modifiers,
             attributes: node.attributes,
-            trivia: node.leadingTrivia,
+            trivia: node.commentCommandTrivia,
             parameterClause: node.parameterClause,
             returnClause: node.returnClause,
             genericParameterClause: node.genericParameterClause,
@@ -192,7 +192,7 @@ public final class DeclarationSyntaxVisitor: PeripherySyntaxVisitor {
                 parse(
                     modifiers: node.modifiers,
                     attributes: node.attributes,
-                    trivia: node.leadingTrivia,
+                    trivia: node.commentCommandTrivia,
                     variableType: binding.typeAnnotation?.type,
                     closureParameterClause: closureParameters,
                     returnClause: closureSignature?.returnClause,
@@ -210,7 +210,7 @@ public final class DeclarationSyntaxVisitor: PeripherySyntaxVisitor {
                 parse(
                     modifiers: node.modifiers,
                     attributes: node.attributes,
-                    trivia: node.leadingTrivia,
+                    trivia: node.leadingTrivia.merging(node.trailingTrivia),
                     at: binding.positionAfterSkippingLeadingTrivia
                 )
             }
@@ -237,7 +237,7 @@ public final class DeclarationSyntaxVisitor: PeripherySyntaxVisitor {
                 parse(
                     modifiers: node.modifiers,
                     attributes: node.attributes,
-                    trivia: node.leadingTrivia,
+                    trivia: node.commentCommandTrivia,
                     variableType: type?.type,
                     variableInitFunctionCallExpr: initializer?.expression.as(FunctionCallExprSyntax.self),
                     at: element.positionAfterSkippingLeadingTrivia
@@ -250,7 +250,7 @@ public final class DeclarationSyntaxVisitor: PeripherySyntaxVisitor {
         parse(
             modifiers: node.modifiers,
             attributes: node.attributes,
-            trivia: node.leadingTrivia,
+            trivia: node.leadingTrivia.merging(node.trailingTrivia),
             genericParameterClause: node.genericParameterClause,
             genericWhereClause: node.genericWhereClause,
             typeInitializerClause: node.initializer,
@@ -262,7 +262,7 @@ public final class DeclarationSyntaxVisitor: PeripherySyntaxVisitor {
         parse(
             modifiers: node.modifiers,
             attributes: node.attributes,
-            trivia: node.leadingTrivia,
+            trivia: node.leadingTrivia.merging(node.trailingTrivia),
             inheritanceClause: node.inheritanceClause,
             genericWhereClause: node.genericWhereClause,
             typeInitializerClause: node.initializer,
@@ -274,7 +274,7 @@ public final class DeclarationSyntaxVisitor: PeripherySyntaxVisitor {
         parse(
             modifiers: nil,
             attributes: nil,
-            trivia: node.leadingTrivia,
+            trivia: node.commentCommandTrivia,
             at: node.name.positionAfterSkippingLeadingTrivia
         )
     }
@@ -283,7 +283,7 @@ public final class DeclarationSyntaxVisitor: PeripherySyntaxVisitor {
         parse(
             modifiers: node.modifiers,
             attributes: node.attributes,
-            trivia: node.leadingTrivia,
+            trivia: node.commentCommandTrivia,
             at: node.name.positionAfterSkippingLeadingTrivia
         )
     }
@@ -517,3 +517,64 @@ public final class DeclarationSyntaxVisitor: PeripherySyntaxVisitor {
             }
     }
 }
+
+// MARK: - Inline Comment Commands
+
+private extension SyntaxProtocol {
+    /// All trivia where inline comment commands can be found.
+    ///
+    /// Matches uses like these:
+    ///
+    /// ```
+    /// // periphery:ignore
+    /// Foo {
+    /// }
+    /// ```
+    ///
+    /// ```
+    /// Foo { // periphery:ignore
+    /// }
+    /// ```
+    ///
+    /// ```
+    /// Foo {} // periphery:ignore
+    /// ```
+    var commentCommandTrivia: Trivia {
+        var commandTrivia = leadingTrivia
+
+        if let hasMemberBlock = self as? HasMemberBlock {
+            commandTrivia = commandTrivia
+                .merging(hasMemberBlock.memberBlock.leftBrace.trailingTrivia)
+                .merging(hasMemberBlock.memberBlock.rightBrace.trailingTrivia)
+        }
+
+        if let hasCodeBody = self as? HasCodeBody, let body = hasCodeBody.body {
+            commandTrivia = commandTrivia
+                .merging(body.leftBrace.trailingTrivia)
+                .merging(body.rightBrace.trailingTrivia)
+        }
+
+        return commandTrivia
+    }
+}
+
+/// Identifies types with a MemberBlockSyntax child
+private protocol HasMemberBlock {
+    var memberBlock: MemberBlockSyntax { get }
+}
+
+extension ActorDeclSyntax: HasMemberBlock {}
+extension ClassDeclSyntax: HasMemberBlock {}
+extension ProtocolDeclSyntax: HasMemberBlock {}
+extension ExtensionDeclSyntax: HasMemberBlock {}
+extension StructDeclSyntax: HasMemberBlock {}
+extension EnumDeclSyntax: HasMemberBlock {}
+
+/// Identifies types with a CodeBlockSyntax child
+private protocol HasCodeBody {
+    var body: CodeBlockSyntax? { get }
+}
+
+extension FunctionDeclSyntax: HasCodeBody {}
+extension InitializerDeclSyntax: HasCodeBody {}
+extension DeinitializerDeclSyntax: HasCodeBody {}

--- a/Tests/Fixtures/Sources/RetentionFixtures/testIgnoreComments.swift
+++ b/Tests/Fixtures/Sources/RetentionFixtures/testIgnoreComments.swift
@@ -67,3 +67,49 @@ public class FixtureClass213: Fixture114 {
 public protocol Fixture205Protocol {}
 // periphery:ignore
 public class Fixture205: Fixture205Protocol {}
+
+// MARK: - Inline comment commands
+
+public class Fixture300Class { // periphery:ignore
+}
+
+public class Fixture301Class {} // periphery:ignore
+
+public protocol Fixture302Protocol { // periphery:ignore
+}
+
+public protocol Fixture303Protocol {} // periphery:ignore
+
+public struct Fixture304Struct { // periphery:ignore
+}
+
+public struct Fixture305Struct {} // periphery:ignore
+
+public protocol Fixture306Protocol {}
+public extension Fixture306Protocol { // periphery:ignore
+    func foo() {}
+}
+
+public enum Fixture307Enum { // periphery:ignore
+    case foo
+}
+
+public class Fixture308Class {
+    var storage: String
+
+    public init() {
+        storage = "noValue"
+    }
+
+    public init(string: String) { // periphery:ignore
+        storage = string
+    }
+
+    public func someFunc() { // periphery:ignore
+        storage = "someFunc"
+    }
+}
+
+public class Fixture309Class { // periphery:ignore
+    public let reference = Fixture308Class()
+}

--- a/Tests/PeripheryTests/RetentionTest.swift
+++ b/Tests/PeripheryTests/RetentionTest.swift
@@ -938,6 +938,30 @@ final class RetentionTest: FixtureSourceGraphTestCase {
             assertReferenced(.protocol("Fixture205Protocol"))
             assertNotRedundantProtocol("Fixture205Protocol")
         }
+
+        // inline comment command tests
+        analyze(retainPublic: false) {
+            assertReferenced(.class("Fixture300Class"))
+            assertReferenced(.class("Fixture301Class"))
+
+            assertReferenced(.protocol("Fixture302Protocol"))
+            assertNotRedundantProtocol("Fixture302Protocol")
+            assertReferenced(.protocol("Fixture303Protocol"))
+            assertNotRedundantProtocol("Fixture303Protocol")
+
+            assertReferenced(.struct("Fixture304Struct"))
+            assertReferenced(.struct("Fixture305Struct"))
+
+            assertReferenced(.extensionProtocol("Fixture306Protocol"))
+            assertNotRedundantProtocol("Fixture306Protocol")
+
+            assertReferenced(.enum("Fixture307Enum"))
+
+            assertReferenced(.class("Fixture308Class")) {
+                self.assertReferenced(.functionMethodInstance("someFunc()"))
+                self.assertReferenced(.functionConstructor("init(string:)"))
+            }
+        }
     }
 
     func testIgnoreAllComment() {


### PR DESCRIPTION
A follow up to https://github.com/peripheryapp/periphery/pull/881 to allow inline comment commands on most declarations.

This was prompted by the awkwardness of ignoring a type that has an existing doc comment.  Putting the command above the doc comment puts it far away from the declaration itself and putting it below can trigger SwiftLint's [`orphaned_doc_comment`](https://realm.github.io/SwiftLint/orphaned_doc_comment.html) lint rule.

```swift
// periphery:ignore
/// Some documentation
/// 
/// 
/// 
/// 
/// That could be very long
class Foo {
    ...
}
```

```swift
/// Some documentation
// periphery:ignore
class Foo {
    ...
}
```

Instead this allows you to use this construction:

```swift
/// Some documentation
class Foo { // periphery:ignore
    ...
}
```