### PR TITLE
Accept Configuration.buildArguments in the Bazel scan

### DIFF
--- a/Sources/ProjectDrivers/BazelProjectDriver.swift
+++ b/Sources/ProjectDrivers/BazelProjectDriver.swift
@@ -106,13 +106,16 @@ public class BazelProjectDriver: ProjectDriver {
             logger.info("\(asterisk) Building...")
         }
 
-        let status = try shell.execStatus([
+        var arguments = [
             "bazel",
             "run",
             "--check_visibility=false",
             "--ui_event_filters=-info,-debug,-warning",
-            "@periphery_generated//:scan",
-        ])
+        ]
+        arguments.append(contentsOf: configuration.buildArguments)
+        arguments.append("@periphery_generated//:scan")
+
+        let status = try shell.execStatus(arguments)
 
         // The actual scan is performed by Bazel.
         exit(status)


### PR DESCRIPTION
In certain Bazel projects, `deps` are sensitive to configuration flags. It would be useful to repurpose `Configuration`'s `buildArguments` when using the Bazel project driver, so these types of Bazel projects can detect dead code in various configurations without having to roll their own generic project config file.