### PR TITLE
Add gitlab-codequality formatting option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ##### Enhancements
 
 - Added the `--retain-unused-imported-modules` option.
+- Added the `--format gitlab-codemagic` formatting option for GitLabs Code Quality artifact reports
 
 ##### Bug Fixes
 

--- a/Sources/Configuration/OutputFormat.swift
+++ b/Sources/Configuration/OutputFormat.swift
@@ -8,6 +8,7 @@ public enum OutputFormat: String, CaseIterable {
     case codeclimate
     case githubActions = "github-actions"
     case githubMarkdown = "github-markdown"
+    case gitlabCodeQuality = "gitlab-codequality"
 
     public static let `default` = OutputFormat.xcode
 

--- a/Sources/PeripheryKit/Results/GitLabCodeQualityFormatter.swift
+++ b/Sources/PeripheryKit/Results/GitLabCodeQualityFormatter.swift
@@ -1,0 +1,59 @@
+import Configuration
+import Foundation
+import SystemPackage
+
+final class GitLabCodeQualityFormatter: OutputFormatter {
+    let configuration: Configuration
+    lazy var currentFilePath: FilePath = .current
+
+    init(configuration: Configuration) {
+        self.configuration = configuration
+    }
+
+    func format(_ results: [ScanResult], colored: Bool) throws -> String? {
+        var jsonObject: [Any] = []
+
+        for result in results {
+            let violationFileLocation = declarationLocation(from: result.declaration)
+
+            let description = describe(result, colored: colored)
+                .map(\.1)
+                .joined(separator: ", ")
+
+            let checkName = describe(result.annotation)
+
+            let fingerprint = result
+                .declaration
+                .usrs
+                .sorted()
+                .joined(separator: ".")
+
+            let begin = violationFileLocation.line
+            let lines: [AnyHashable: Any] = [
+                "begin": begin
+            ]
+
+            let path = outputPath(violationFileLocation)
+                .url
+                .relativePath
+
+            let location: [AnyHashable: Any] = [
+                "path": path,
+                "lines": lines,
+            ]
+
+            let object: [AnyHashable: Any] = [
+                "description": description,
+                "check_name": checkName,
+                "fingerprint": fingerprint,
+                "location": location,
+                "severity": "info",
+            ]
+
+            jsonObject.append(object)
+        }
+
+        let data = try JSONSerialization.data(withJSONObject: jsonObject, options: [.prettyPrinted, .withoutEscapingSlashes])
+        return String(bytes: data, encoding: .utf8)
+    }
+}

--- a/Sources/PeripheryKit/Results/OutputFormatter.swift
+++ b/Sources/PeripheryKit/Results/OutputFormatter.swift
@@ -178,6 +178,8 @@ public extension OutputFormat {
             GitHubActionsFormatter.self
         case .githubMarkdown:
             GitHubMarkdownFormatter.self
+        case .gitlabCodeQuality:
+            GitLabCodeQualityFormatter.self
         }
     }
 }


### PR DESCRIPTION
Hello,

I came across GitLabs `merge_request` decorating capabilities - especially the [code quality](https://docs.gitlab.com/ci/yaml/artifacts_reports/#artifactsreportscodequality) [widget](https://docs.gitlab.com/ci/testing/code_quality/#view-code-quality-results). It expects something very [similar](https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format) to CodeMagics JSON, however that misses a single property.

I simply added a new formatter with near identical code as a first draft (because it's easy and fast). If someone things doing a bit more effort to deduplicate code, I'm happy to do so - wasn't sure for now.

I could also add an optional flag to let the user decide the severity? 

Anyway, some feedback is highly appreciated! 