### PR TITLE
Allow the dependency graph to be exported as JSON

### DIFF
--- a/Sources/Configuration/Configuration.swift
+++ b/Sources/Configuration/Configuration.swift
@@ -152,6 +152,9 @@ public final class Configuration {
     @Setting(key: "bazel_check_visibility", defaultValue: false)
     public var bazelCheckVisibility: Bool
 
+    @Setting(key: "export_graph", defaultValue: nil)
+    public var exportGraph: FilePath?
+
     // Non user facing.
     public var guidedSetup: Bool = false
     public var projectRoot: FilePath = .init()

--- a/Sources/Frontend/Commands/ScanCommand.swift
+++ b/Sources/Frontend/Commands/ScanCommand.swift
@@ -162,6 +162,9 @@ struct ScanCommand: ParsableCommand {
     @Flag(help: "Enable Bazel visibility checking")
     var bazelCheckVisibility: Bool = defaultConfiguration.$bazelCheckVisibility.defaultValue
 
+    @Option(help: "Export dependancy graph as JSON to file path")
+    var exportGraph: FilePath?
+
     private static let defaultConfiguration = Configuration()
 
     func run() throws {
@@ -223,6 +226,7 @@ struct ScanCommand: ParsableCommand {
         configuration.apply(\.$bazelFilter, bazelFilter)
         configuration.apply(\.$bazelIndexStore, bazelIndexStore)
         configuration.apply(\.$bazelCheckVisibility, bazelCheckVisibility)
+        configuration.apply(\.$exportGraph, exportGraph)
 
         configuration.buildFilenameMatchers()
 

--- a/Sources/Frontend/Scan.swift
+++ b/Sources/Frontend/Scan.swift
@@ -6,6 +6,7 @@ import PeripheryKit
 import ProjectDrivers
 import Shared
 import SourceGraph
+import SystemPackage
 
 final class Scan {
     private let configuration: Configuration
@@ -46,6 +47,9 @@ final class Scan {
         try build(driver)
         let loc = try index(driver)
         try analyze()
+        if let graphPath = configuration.exportGraph {
+            try exportGraph(graphPath: graphPath)
+        }
         return Output(results: buildResults(), loc: loc)
     }
 
@@ -96,6 +100,12 @@ final class Scan {
             swiftVersion: swiftVersion
         ).perform()
         logger.endInterval(analyzeInterval)
+    }
+
+    private func exportGraph(graphPath: FilePath) throws {
+        let exportGraphInterval = logger.beginInterval("exportGraph")
+        try SourceGraphExporter().describeGraph(graph: graph, to: graphPath.url)
+        logger.endInterval(exportGraphInterval)
     }
 
     private func buildResults() -> [ScanResult] {

--- a/Sources/SourceGraph/SourceGraphExporter.swift
+++ b/Sources/SourceGraph/SourceGraphExporter.swift
@@ -1,0 +1,139 @@
+// periphery:ignore:all
+
+import Foundation
+
+public enum JSON {
+    case object([String:JSON])
+    case array([JSON])
+    case string(String)
+    case bool(Bool)
+    case null
+}
+
+extension JSON: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .object(let dictionary):
+            try container.encode(dictionary)
+        case .array(let array):
+            try container.encode(array)
+        case .string(let string):
+            try container.encode(string)
+        case .bool(let bool):
+            try container.encode(bool)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+}
+
+public final class SourceGraphExporter {
+    public required init() {
+    }
+
+    public func describeGraph(graph: SourceGraph) -> JSON {
+        var dictionary = [String:JSON]()
+        dictionary["rootDeclarations"] = describe(graph.rootDeclarations.sorted())
+        dictionary["rootReferences"] = describe(graph.rootReferences.sorted())
+        return .object(dictionary)
+    }
+
+    public func describeGraph(graph: SourceGraph, to url: URL) throws {
+        let json = describeGraph(graph: graph)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        let data = try encoder.encode(json)
+        try data.write(to: url)
+    }
+
+    // MARK: - Private
+
+    private func describe(_ declarations: any Sequence<Declaration>) -> JSON {
+        .array(declarations.map(describe))
+    }
+
+    private func describe(_ references: any Sequence<Reference>) -> JSON {
+        .array(references.map(describe))
+    }
+
+    private func describe(_ declaration: Declaration)  -> JSON {
+        var dictionary = [String:JSON]()
+        dictionary["$isa"] = .string("declaration")
+
+        dictionary["location"] = describe(declaration.location)
+        dictionary["attributes"] = describe(declaration.attributes)
+        dictionary["modifiers"] = describe(declaration.modifiers)
+        dictionary["accessibility"] = describe(declaration.accessibility.value)
+        dictionary["kind"] = describe(declaration.kind)
+        dictionary["name"] = describe(declaration.name)
+        dictionary["usrs"] = describe(declaration.usrs)
+        dictionary["unusedParameters"] = describe(declaration.unusedParameters)
+        dictionary["declarations"] = describe(declaration.declarations)
+        dictionary["references"] = describe(declaration.references)
+        dictionary["declaredType"] = describe(declaration.declaredType)
+        dictionary["displayName"] = describe(declaration.kind.displayName)
+
+        if let parent = declaration.parent {
+            dictionary["parent"] = .array(parent.usrs.map({.string($0)}))
+        }
+        dictionary["immediateInheritedTypeReferences"] = describe(declaration.immediateInheritedTypeReferences)
+        dictionary["isImplicit"] = describe(declaration.isImplicit)
+        dictionary["isObjcAccessible"] = describe(declaration.isObjcAccessible)
+
+        dictionary["related"] = describe(declaration.related)
+        dictionary["references"] = describe(declaration.references)
+        dictionary["declarations"] = describe(declaration.declarations)
+        return .object(dictionary)
+    }
+
+    private func describe(_ reference: Reference) -> JSON {
+        return describe(reference.usr)
+    }
+
+    // MARK: - Extra
+
+    private func describe(_ value: Location) -> JSON {
+        return .string(value.file.path.string)
+    }
+
+    private func describe(_ value: Declaration.Kind) -> JSON {
+        .string(value.rawValue)
+    }
+
+    private func describe(_ value: Reference.Role) -> JSON {
+        .string(value.rawValue)
+    }
+
+    private func describe(_ value: String?) -> JSON {
+        if let value {
+            return .string(value)
+        } else {
+            return .null
+        }
+    }
+
+    private func describe(_ value: Set<String>) -> JSON {
+        return .array(value.sorted().map(describe))
+    }
+
+    private func describe(_ value: Set<DeclarationAttribute>) -> JSON {
+        return .array(value.sorted().map(describe))
+    }
+
+    private func describe(_ value: DeclarationAttribute) -> JSON {
+        var dictionary = [String:JSON]()
+        dictionary["$isa"] = .string("declarationAttribute")
+        dictionary["name"] = describe(value.name)
+        dictionary["arguments"] = describe(value.arguments)
+        return .object(dictionary)
+    }
+
+    private func describe<T: RawRepresentable>(_ value: T) -> JSON where T.RawValue == String {
+        describe(value.rawValue)
+    }
+
+    private func describe(_ value: Bool) -> JSON {
+        return .bool(value)
+    }
+}


### PR DESCRIPTION
Being able to export the source graph to other tools is extremely useful as it allows for usage outside the scope of the project without creating or requiring a public API (or the user having to create a swift wrapper just to get the information they need).

For example, with this change, it is possible to generate nice dependency charts such as described here: https://github.com/peripheryapp/periphery/discussions/758.