### PR TITLE
Provide more verbose error information when failing to index plists, xcdatamodels, and xibs

### DIFF
--- a/Sources/Indexer/InfoPlistIndexer.swift
+++ b/Sources/Indexer/InfoPlistIndexer.swift
@@ -5,6 +5,9 @@ import SourceGraph
 import SystemPackage
 
 final class InfoPlistIndexer: Indexer {
+    enum PlistError: Error {
+        case failedToParse(path: FilePath, underlyingError: Error)
+    }
     private let infoPlistFiles: Set<FilePath>
     private let graph: SynchronizedSourceGraph
     private let logger: ContextualLogger
@@ -24,9 +27,13 @@ final class InfoPlistIndexer: Indexer {
             guard let self else { return }
 
             let elapsed = try Benchmark.measure {
-                try InfoPlistParser(path: path)
-                    .parse()
-                    .forEach { self.graph.add($0) }
+                do {
+                    try InfoPlistParser(path: path)
+                        .parse()
+                        .forEach { self.graph.add($0) }
+                } catch {
+                    throw PlistError.failedToParse(path: path, underlyingError: error)
+                }
             }
 
             logger.debug("\(path.string) (\(elapsed)s)")

--- a/Sources/Indexer/XCDataModelIndexer.swift
+++ b/Sources/Indexer/XCDataModelIndexer.swift
@@ -5,6 +5,9 @@ import SourceGraph
 import SystemPackage
 
 final class XCDataModelIndexer: Indexer {
+    enum XCDataModelError: Error {
+        case failedToParse(path: FilePath, underlyingError: Error)
+    }
     private let files: Set<FilePath>
     private let graph: SynchronizedSourceGraph
     private let logger: ContextualLogger
@@ -24,9 +27,13 @@ final class XCDataModelIndexer: Indexer {
             guard let self else { return }
 
             let elapsed = try Benchmark.measure {
-                try XCDataModelParser(path: path)
-                    .parse()
-                    .forEach { self.graph.add($0) }
+                do {
+                    try XCDataModelParser(path: path)
+                        .parse()
+                        .forEach { self.graph.add($0) }
+                } catch {
+                    throw XCDataModelError.failedToParse(path: path, underlyingError: error)
+                }
             }
 
             logger.debug("\(path.string) (\(elapsed)s)")

--- a/Sources/Indexer/XibIndexer.swift
+++ b/Sources/Indexer/XibIndexer.swift
@@ -5,6 +5,9 @@ import SourceGraph
 import SystemPackage
 
 final class XibIndexer: Indexer {
+    enum XibError: Error {
+        case failedToParse(path: FilePath, underlyingError: Error)
+    }
     private let xibFiles: Set<FilePath>
     private let graph: SynchronizedSourceGraph
     private let logger: ContextualLogger
@@ -24,9 +27,13 @@ final class XibIndexer: Indexer {
             guard let self else { return }
 
             let elapsed = try Benchmark.measure {
-                try XibParser(path: xibPath)
-                    .parse()
-                    .forEach { self.graph.add($0) }
+                do {
+                    try XibParser(path: xibPath)
+                        .parse()
+                        .forEach { self.graph.add($0) }
+                } catch {
+                    throw XibError.failedToParse(path: xibPath, underlyingError: error)
+                }
             }
 
             logger.debug("\(xibPath.string) (\(elapsed)s)")


### PR DESCRIPTION
Provide additional error details when failing to parse `Info.plist`, `.xcdatamodel`, or `.xib` files.

Today when there's an error trying to parse one of these files, its unclear the context in which the error is coming from (unless you happen to run with `--verbose`, which allows to guess based on the previous log outputs), why its happening, and what file / content it is failing to read.

## Examples:

### `Info.plist`

Before:

> error: The operation couldn’t be completed. (NSXMLParserErrorDomain error 4.)

After:

> error: failedToParse(path: "/path/to/Info.plist", underlyingError: Error Domain=NSXMLParserErrorDomain Code=4 "(null)" UserInfo={NSXMLParserErrorColumn=1, NSXMLParserErrorLineNumber=1, NSXMLParserErrorMessage=Document is empty
})

Context: I have a bazel project that generates some `Info.plist` files that are written in JSON instead of XML, and the above is the error that happens when periphery tries to read them.

### `.xcdatamodel` 

Before:

> error: The file “contents” couldn’t be opened.

After:

> error: failedToParse(path: "/path/to/DataModel.xcdatamodeld/DataModel.xcdatamodel/contents", underlyingError: Error Domain=NSCocoaErrorDomain Code=256 "The file “contents” couldn’t be opened." UserInfo={NSUserStringVariant=(
    Folder
), NSURL=file:///path/to/DataModel.xcdatamodeld/DataModel.xcdatamodel/contents/, NSFilePath=/path/to/DataModel.xcdatamodeld/DataModel.xcdatamodel/contents, NSUnderlyingError=0x600003078750 {Error Domain=NSPOSIXErrorDomain Code=20 "Not a directory"}})



