### PR TITLE
Improve the performance of ProtocolConformanceReferenceBuilder through parallelism

### DIFF
--- a/Sources/Indexer/SourceFileCollector.swift
+++ b/Sources/Indexer/SourceFileCollector.swift
@@ -4,6 +4,7 @@ import Logger
 import SourceGraph
 import SwiftIndexStore
 import SystemPackage
+import Shared
 
 public struct SourceFileCollector {
     private let indexStorePaths: Set<FilePath>


### PR DESCRIPTION
The `ProtocolConformanceReferenceBuilder` takes a significant amount of time in a monorepo of ours that has a large amount of types and protocols.

This PR updates `ProtocolConformanceReferenceBuilder` to parallelize the step that searches the graph for implementations of a protocol and for class hierarchies. This reduces the runtime in mentioned monorepo from ~6 minutes to ~70 seconds.