### PR TITLE
Add --bazel-index-store argument to scan command

### DIFF
--- a/Sources/Configuration/Configuration.swift
+++ b/Sources/Configuration/Configuration.swift
@@ -137,6 +137,10 @@ public final class Configuration {
     @Setting(key: "bazel_filter", defaultValue: nil)
     public var bazelFilter: String?
 
+    @Setting(key: "bazel_index_store", defaultValue: nil)
+    public var bazelIndexStore: FilePath?
+
+
     // Non user facing.
     public var guidedSetup: Bool = false
     public var projectRoot: FilePath = .init()
@@ -208,7 +212,7 @@ public final class Configuration {
         $externalTestCaseClasses, $verbose, $quiet, $disableUpdateCheck, $strict, $indexStorePath, $skipBuild,
         $skipSchemesValidation, $cleanBuild, $buildArguments, $xcodeListArguments, $relativeResults, $jsonPackageManifestPath,
         $retainCodableProperties, $retainEncodableProperties, $baseline, $writeBaseline, $writeResults, $genericProjectConfig,
-        $bazel, $bazelFilter,
+        $bazel, $bazelFilter, $bazelIndexStore
     ]
 
     private func buildFilenameMatchers(with patterns: [String]) -> [FilenameMatcher] {

--- a/Sources/Frontend/Commands/ScanCommand.swift
+++ b/Sources/Frontend/Commands/ScanCommand.swift
@@ -144,6 +144,9 @@ struct ScanCommand: FrontendCommand {
     @Option(help: "Filter pattern applied to the Bazel top-level targets query")
     var bazelFilter: String?
 
+    @Option(help: "Path to a global index store populated by Bazel. If provided, will be used instead of individual module stores.")
+    var bazelIndexStore: FilePath?
+
     private static let defaultConfiguration = Configuration()
 
     func run() throws {
@@ -200,6 +203,7 @@ struct ScanCommand: FrontendCommand {
         configuration.apply(\.$genericProjectConfig, genericProjectConfig)
         configuration.apply(\.$bazel, bazel)
         configuration.apply(\.$bazelFilter, bazelFilter)
+        configuration.apply(\.$bazelIndexStore, bazelIndexStore)
 
         configuration.buildFilenameMatchers()
 

--- a/Sources/ProjectDrivers/BazelProjectDriver.swift
+++ b/Sources/ProjectDrivers/BazelProjectDriver.swift
@@ -85,6 +85,9 @@ public class BazelProjectDriver: ProjectDriver {
 
         let buildPath = outputPath.appending("BUILD.bazel")
         let deps = try queryTargets().joined(separator: ",\n")
+        let globalIndexStoreValue = configuration.bazelIndexStore.map {
+            "\"\(FilePath.makeAbsolute($0)))\""
+        } ?? "None"
         let buildFileContents = """
         load("@periphery//bazel:rules.bzl", "scan")
 
@@ -92,6 +95,7 @@ public class BazelProjectDriver: ProjectDriver {
           name = "scan",
           testonly = True,
           config = "\(configPath)",
+          global_indexstore = \(globalIndexStoreValue),
           deps = [
             \(deps)
           ],

--- a/bazel/internal/scan/scan.bzl
+++ b/bazel/internal/scan/scan.bzl
@@ -165,8 +165,12 @@ def scan_impl(ctx):
     xcmappingmodels = sets.to_list(xcmappingmodels_set)
     test_targets = sets.to_list(test_targets_set)
 
+    indexstores_config = [file.path for file in indexstores]
+    if ctx.attr.global_indexstore:
+        indexstores_config = [ctx.attr.global_indexstore]
+
     project_config = struct(
-        indexstores = [file.path for file in indexstores],
+        indexstores = indexstores_config,
         plists = [file.path for file in plists],
         xibs = [file.path for file in xibs],
         xcdatamodels = [file.path for file in xcdatamodels],

--- a/bazel/rules.bzl
+++ b/bazel/rules.bzl
@@ -14,6 +14,7 @@ scan = rule(
             doc = "Top-level project targets to scan.",
         ),
         "config": attr.string(doc = "Path to the periphery.yml configuration file."),
+        "global_indexstore": attr.string(doc = "Path to a global index store."),
         "periphery": attr.label(
             doc = "The periphery executable target.",
             default = "@periphery//:periphery",


### PR DESCRIPTION
* Adds a new flag `--bazel-index-store` for providing a path to a global index store used by all modules compiled by Bazel
* Adds logic to the Bazel rules to use the provided `--bazel-index-store` value to populate `indexstores` in the project config instead of populating with the list of module specific stores


This is motivated by https://github.com/peripheryapp/periphery/issues/977 where a project with a large number of indexstore files will result in a crash due to the periphery process hitting a limit of open file descriptors.

## Usage

For Bazel projects using `rules_swift`, enable the [swift.use_global_index_store](https://github.com/bazelbuild/rules_swift/blob/f84622605cf1b54eb97f180a810358860cc9211e/swift/internal/feature_names.bzl#L87-L88) feature and then pass `--bazel-index-store bazel-out/_global_index_store`