### PR TITLE
Avoid recreating LibIndexStore for every indexstore file

### DIFF
--- a/Sources/Indexer/SourceFileCollector.swift
+++ b/Sources/Indexer/SourceFileCollector.swift
@@ -26,11 +26,12 @@ public struct SourceFileCollector {
     public func collect() throws -> [SourceFile: [IndexUnit]] {
         let excludedTargets = excludedTestTargets.union(configuration.excludeTargets)
         let currentFilePath = FilePath.current
+        let lib = try LibIndexStore.open()
 
         return try JobPool(jobs: Array(indexStorePaths))
             .flatMap { indexStorePath in
                 logger.debug("Reading \(indexStorePath)")
-                let indexStore = try IndexStore.open(store: URL(fileURLWithPath: indexStorePath.string), lib: .open())
+                let indexStore = try IndexStore.open(store: URL(fileURLWithPath: indexStorePath.string), lib: lib)
                 let units = indexStore.units(includeSystem: false)
 
                 return try units.compactMap { unit -> (FilePath, IndexStore, IndexStoreUnit, String?)? in


### PR DESCRIPTION
Reuse an instance of `LibIndexStore` when collecting source files.

Calls to `LibIndexStore.open()` will trigger a [process spawn](https://github.com/kateinoigakukun/swift-indexstore/blob/055264ececff53c1265c2b7ee3513053b02604de/Sources/SwiftIndexStore/LibIndexStore.swift#L77-L80) to either `xcode-select` (macOS) or `which` (Linux) each time its called, and this code path is hit once per entry in `indexstores`. This currently causes thousands of invocations of `xcode-select` on a large project.