### PR TITLE
Fix superclass initializer false-positive when called on subclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fix indexing of xib/storyboard files in SPM projects.
 - Fix types conforming to App Intents protocols being reported as unused.
+- Fix superclass initializer reported as unused when called on subclass.
 
 ## 3.3.0 (2025-12-13)
 

--- a/Sources/BUILD.bazel
+++ b/Sources/BUILD.bazel
@@ -69,6 +69,7 @@ swift_library(
         "SourceGraph/Mutators/ExternalOverrideRetainer.swift",
         "SourceGraph/Mutators/ExternalTypeProtocolConformanceReferenceRemover.swift",
         "SourceGraph/Mutators/GenericClassAndStructConstructorReferenceBuilder.swift",
+        "SourceGraph/Mutators/InheritedImplicitInitializerReferenceBuilder.swift",
         "SourceGraph/Mutators/InterfaceBuilderPropertyRetainer.swift",
         "SourceGraph/Mutators/ObjCAccessibleRetainer.swift",
         "SourceGraph/Mutators/PropertyWrapperRetainer.swift",

--- a/Sources/SourceGraph/Mutators/InheritedImplicitInitializerReferenceBuilder.swift
+++ b/Sources/SourceGraph/Mutators/InheritedImplicitInitializerReferenceBuilder.swift
@@ -1,0 +1,52 @@
+import Configuration
+import Foundation
+import Shared
+
+/// Builds references from implicit inherited initializers to the superclass initializer they inherit.
+///
+/// When a subclass inherits an initializer from its superclass, the index store records a relationship
+/// from the superclass initializer to the subclass implicit initializer, but not the inverse. This mutator
+/// adds the inverse reference so that when the implicit initializer is used, the superclass initializer
+/// is also marked as used.
+final class InheritedImplicitInitializerReferenceBuilder: SourceGraphMutator {
+    private let graph: SourceGraph
+
+    required init(graph: SourceGraph, configuration _: Configuration, swiftVersion _: SwiftVersion) {
+        self.graph = graph
+    }
+
+    func mutate() {
+        for classDecl in graph.declarations(ofKind: .class) {
+            // Find explicit (non-implicit) initializers in this class
+            let explicitInitializers = classDecl.declarations.filter {
+                $0.kind == .functionConstructor && !$0.isImplicit
+            }
+
+            for explicitInit in explicitInitializers {
+                // Check if this initializer has related references to implicit initializers in subclasses
+                for relatedRef in explicitInit.related {
+                    guard relatedRef.kind == .functionConstructor else { continue }
+
+                    // Find the declaration this related reference points to
+                    guard let implicitInit = graph.declaration(withUsr: relatedRef.usr),
+                          implicitInit.isImplicit,
+                          implicitInit.kind == .functionConstructor
+                    else { continue }
+
+                    // Add the inverse reference: implicit init -> explicit init
+                    for usr in explicitInit.usrs {
+                        let reference = Reference(
+                            kind: .functionConstructor,
+                            usr: usr,
+                            location: implicitInit.location,
+                            isRelated: true
+                        )
+                        reference.name = explicitInit.name
+                        reference.parent = implicitInit
+                        graph.add(reference, from: implicitInit)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/SourceGraph/SourceGraphMutatorRunner.swift
+++ b/Sources/SourceGraph/SourceGraphMutatorRunner.swift
@@ -29,6 +29,7 @@ public final class SourceGraphMutatorRunner {
         EnumCaseReferenceBuilder.self,
         DefaultConstructorReferenceBuilder.self,
         StructImplicitInitializerReferenceBuilder.self,
+        InheritedImplicitInitializerReferenceBuilder.self,
 
         DynamicMemberRetainer.self,
         UnusedParameterRetainer.self,

--- a/Tests/Fixtures/Sources/RetentionFixtures/testRetainsSuperclassInitializerCalledOnSubclass.swift
+++ b/Tests/Fixtures/Sources/RetentionFixtures/testRetainsSuperclassInitializerCalledOnSubclass.swift
@@ -1,0 +1,11 @@
+class FixtureClass221Parent {
+    init(param: String) {}
+}
+
+class FixtureClass221Child: FixtureClass221Parent {}
+
+public class FixtureClass221Retainer {
+    public func retain() {
+        _ = FixtureClass221Child(param: "foo")
+    }
+}

--- a/Tests/PeripheryTests/RetentionTest.swift
+++ b/Tests/PeripheryTests/RetentionTest.swift
@@ -1679,6 +1679,18 @@ final class RetentionTest: FixtureSourceGraphTestCase {
         }
     }
 
+    // MARK: - Inherited Initializers
+
+    // https://github.com/peripheryapp/periphery/issues/957
+    func testRetainsSuperclassInitializerCalledOnSubclass() {
+        analyze(retainPublic: true) {
+            assertReferenced(.class("FixtureClass221Parent")) {
+                self.assertReferenced(.functionConstructor("init(param:)"))
+            }
+            assertReferenced(.class("FixtureClass221Child"))
+        }
+    }
+
     // MARK: - Known Failures
 
     // https://github.com/peripheryapp/periphery/issues/676


### PR DESCRIPTION
When a subclass inherits an initializer from its superclass, calling the initializer on the subclass (e.g., `Child(param: "foo")`) was not marking the superclass initializer as used, causing a false-positive.

The index store records a relationship from the superclass initializer to the subclass implicit initializer, but not the inverse. Added a new mutator (InheritedImplicitInitializerReferenceBuilder) that creates the inverse reference so that when the implicit initializer is used, the superclass initializer is also marked as used.

Fixes #957