### PR TITLE
Fix Swift 6.3+ compatibility for generic protocol extensions

### DIFF
--- a/Sources/Frontend/Scan.swift
+++ b/Sources/Frontend/Scan.swift
@@ -70,7 +70,7 @@ final class Scan {
         let indexLogger = logger.contextualized(with: "index")
         let plan = try driver.plan(logger: indexLogger)
         let syncSourceGraph = SynchronizedSourceGraph(graph: graph)
-        let pipeline = IndexPipeline(plan: plan, graph: syncSourceGraph, logger: indexLogger, configuration: configuration)
+        let pipeline = IndexPipeline(plan: plan, graph: syncSourceGraph, logger: indexLogger, configuration: configuration, swiftVersion: swiftVersion)
         try pipeline.perform()
         logger.endInterval(indexInterval)
     }

--- a/Sources/Indexer/IndexPipeline.swift
+++ b/Sources/Indexer/IndexPipeline.swift
@@ -1,6 +1,7 @@
 import Configuration
 import Foundation
 import Logger
+import Shared
 import SourceGraph
 
 public struct IndexPipeline {
@@ -8,12 +9,14 @@ public struct IndexPipeline {
     private let graph: SynchronizedSourceGraph
     private let logger: ContextualLogger
     private let configuration: Configuration
+    private let swiftVersion: SwiftVersion
 
-    public init(plan: IndexPlan, graph: SynchronizedSourceGraph, logger: ContextualLogger, configuration: Configuration) {
+    public init(plan: IndexPlan, graph: SynchronizedSourceGraph, logger: ContextualLogger, configuration: Configuration, swiftVersion: SwiftVersion) {
         self.plan = plan
         self.graph = graph
         self.logger = logger
         self.configuration = configuration
+        self.swiftVersion = swiftVersion
     }
 
     public func perform() throws {
@@ -21,7 +24,8 @@ public struct IndexPipeline {
             sourceFiles: plan.sourceFiles,
             graph: graph,
             logger: logger,
-            configuration: configuration
+            configuration: configuration,
+            swiftVersion: swiftVersion
         ).perform()
 
         if !plan.plistPaths.isEmpty {

--- a/Sources/Indexer/SwiftIndexer.swift
+++ b/Sources/Indexer/SwiftIndexer.swift
@@ -17,17 +17,20 @@ final class SwiftIndexer: Indexer {
     private let graph: SynchronizedSourceGraph
     private let logger: ContextualLogger
     private let configuration: Configuration
+    private let swiftVersion: SwiftVersion
 
     required init(
         sourceFiles: [SourceFile: [IndexUnit]],
         graph: SynchronizedSourceGraph,
         logger: ContextualLogger,
-        configuration: Configuration
+        configuration: Configuration,
+        swiftVersion: SwiftVersion
     ) {
         self.sourceFiles = sourceFiles
         self.graph = graph
         self.logger = logger.contextualized(with: "swift")
         self.configuration = configuration
+        self.swiftVersion = swiftVersion
         super.init(configuration: configuration)
     }
 
@@ -39,7 +42,8 @@ final class SwiftIndexer: Indexer {
                 retainAllDeclarations: isRetained(file),
                 graph: graph,
                 logger: logger,
-                configuration: configuration
+                configuration: configuration,
+                swiftVersion: swiftVersion
             )
         }
 
@@ -88,6 +92,7 @@ final class SwiftIndexer: Indexer {
         private let logger: ContextualLogger
         private let configuration: Configuration
         private var retainAllDeclarations: Bool
+        private let swiftVersion: SwiftVersion
 
         required init(
             sourceFile: SourceFile,
@@ -95,7 +100,8 @@ final class SwiftIndexer: Indexer {
             retainAllDeclarations: Bool,
             graph: SynchronizedSourceGraph,
             logger: ContextualLogger,
-            configuration: Configuration
+            configuration: Configuration,
+            swiftVersion: SwiftVersion
         ) {
             self.sourceFile = sourceFile
             self.units = units
@@ -103,6 +109,7 @@ final class SwiftIndexer: Indexer {
             self.graph = graph
             self.logger = logger
             self.configuration = configuration
+            self.swiftVersion = swiftVersion
         }
 
         // swiftlint:disable nesting
@@ -242,7 +249,7 @@ final class SwiftIndexer: Indexer {
                 graph.addIndexedModules(sourceFile.modules)
             }
 
-            let multiplexingSyntaxVisitor = try MultiplexingSyntaxVisitor(file: sourceFile)
+            let multiplexingSyntaxVisitor = try MultiplexingSyntaxVisitor(file: sourceFile, swiftVersion: swiftVersion)
             let declarationSyntaxVisitor = multiplexingSyntaxVisitor.add(DeclarationSyntaxVisitor.self)
             let importSyntaxVisitor = multiplexingSyntaxVisitor.add(ImportSyntaxVisitor.self)
 

--- a/Sources/SyntaxAnalysis/ImportSyntaxVisitor.swift
+++ b/Sources/SyntaxAnalysis/ImportSyntaxVisitor.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Shared
 import SourceGraph
 import SwiftSyntax
 
@@ -7,8 +8,9 @@ public final class ImportSyntaxVisitor: PeripherySyntaxVisitor {
 
     private let sourceLocationBuilder: SourceLocationBuilder
 
-    public init(sourceLocationBuilder: SourceLocationBuilder) {
+    public init(sourceLocationBuilder: SourceLocationBuilder, swiftVersion _: SwiftVersion) {
         self.sourceLocationBuilder = sourceLocationBuilder
+        // swiftVersion is not used in this visitor but is required by the protocol
     }
 
     public func visit(_ node: ImportDeclSyntax) {

--- a/Tests/PeripheryTests/Syntax/FunctionVisitTest.swift
+++ b/Tests/PeripheryTests/Syntax/FunctionVisitTest.swift
@@ -1,4 +1,6 @@
 import Foundation
+import Logger
+import Shared
 @testable import SourceGraph
 @testable import SyntaxAnalysis
 @testable import TestShared
@@ -9,7 +11,9 @@ final class FunctionVisitTest: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        let multiplexingVisitor = try MultiplexingSyntaxVisitor(file: fixturePath)
+        let shell = Shell(logger: Logger(quiet: true))
+        let swiftVersion = SwiftVersion(shell: shell)
+        let multiplexingVisitor = try MultiplexingSyntaxVisitor(file: fixturePath, swiftVersion: swiftVersion)
         let visitor = multiplexingVisitor.add(DeclarationSyntaxVisitor.self)
         multiplexingVisitor.visit()
         results = visitor.resultsByLocation

--- a/Tests/PeripheryTests/Syntax/ImportVisitTest.swift
+++ b/Tests/PeripheryTests/Syntax/ImportVisitTest.swift
@@ -1,4 +1,6 @@
 import Foundation
+import Logger
+import Shared
 @testable import SourceGraph
 @testable import SyntaxAnalysis
 @testable import TestShared
@@ -9,7 +11,9 @@ final class ImportVisitTest: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        let multiplexingVisitor = try MultiplexingSyntaxVisitor(file: fixturePath)
+        let shell = Shell(logger: Logger(quiet: true))
+        let swiftVersion = SwiftVersion(shell: shell)
+        let multiplexingVisitor = try MultiplexingSyntaxVisitor(file: fixturePath, swiftVersion: swiftVersion)
         let visitor = multiplexingVisitor.add(ImportSyntaxVisitor.self)
         multiplexingVisitor.visit()
         results = visitor.importStatements

--- a/Tests/PeripheryTests/Syntax/PropertyVisitTest.swift
+++ b/Tests/PeripheryTests/Syntax/PropertyVisitTest.swift
@@ -1,4 +1,6 @@
 import Foundation
+import Logger
+import Shared
 @testable import SourceGraph
 @testable import SyntaxAnalysis
 @testable import TestShared
@@ -9,7 +11,9 @@ final class PropertyVisitTest: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        let multiplexingVisitor = try MultiplexingSyntaxVisitor(file: fixturePath)
+        let shell = Shell(logger: Logger(quiet: true))
+        let swiftVersion = SwiftVersion(shell: shell)
+        let multiplexingVisitor = try MultiplexingSyntaxVisitor(file: fixturePath, swiftVersion: swiftVersion)
         let visitor = multiplexingVisitor.add(DeclarationSyntaxVisitor.self)
         multiplexingVisitor.visit()
         results = visitor.resultsByLocation

--- a/Tests/Shared/SourceGraphTestCase.swift
+++ b/Tests/Shared/SourceGraphTestCase.swift
@@ -55,11 +55,13 @@ open class SourceGraphTestCase: XCTestCase {
         }
 
         graph = SourceGraph(configuration: configuration, logger: logger)
+        let swiftVersion = SwiftVersion(shell: shell)
         let pipeline = IndexPipeline(
             plan: newPlan,
             graph: SynchronizedSourceGraph(graph: graph),
             logger: logger.contextualized(with: "index"),
-            configuration: configuration
+            configuration: configuration,
+            swiftVersion: swiftVersion
         )
         try! pipeline.perform()
 
@@ -68,7 +70,7 @@ open class SourceGraphTestCase: XCTestCase {
             graph: graph,
             logger: logger,
             configuration: configuration,
-            swiftVersion: SwiftVersion(shell: shell)
+            swiftVersion: swiftVersion
         ).perform()
         results = ScanResultBuilder.build(for: graph)
     }


### PR DESCRIPTION
Swift 6.3+ changed the indexstore location for protocol extensions with primary associated type constraints (e.g., 'extension Protocol<Type>'). Previously, the location was after the closing angle bracket, but now it's at the base identifier.