### PR TITLE
Fix false positive for constrained protocol extensions

### DIFF
--- a/Sources/SourceGraph/Mutators/ProtocolConformanceReferenceBuilder.swift
+++ b/Sources/SourceGraph/Mutators/ProtocolConformanceReferenceBuilder.swift
@@ -2,6 +2,12 @@ import Configuration
 import Foundation
 import Shared
 
+/// Inverts references between protocol requirements and their conforming implementations.
+///
+/// The Swift indexer creates references from conforming declarations TO protocol requirements
+/// (e.g., `S.foo -> P.foo`). We invert these so protocol requirements reference their implementations
+/// (`P.foo -> S.foo`). This ensures that when code calls a method on a protocol type, the conforming
+/// implementations are transitively marked as used.
 final class ProtocolConformanceReferenceBuilder: SourceGraphMutator {
     private let graph: SourceGraph
 

--- a/Sources/SourceGraph/Mutators/ProtocolExtensionReferenceBuilder.swift
+++ b/Sources/SourceGraph/Mutators/ProtocolExtensionReferenceBuilder.swift
@@ -2,6 +2,13 @@ import Configuration
 import Foundation
 import Shared
 
+/// Builds references between protocols and their extensions.
+///
+/// This mutator handles:
+/// 1. Creating references from protocols to their extensions
+/// 2. Creating references from conforming types to protocol extensions when they use default implementations
+/// 3. Constrained protocol extensions (e.g., `extension ProtocolA where Self: ProtocolB`) where the extension
+///    provides default implementations that satisfy requirements of the constraining protocol
 final class ProtocolExtensionReferenceBuilder: SourceGraphMutator {
     private let graph: SourceGraph
 
@@ -46,6 +53,53 @@ final class ProtocolExtensionReferenceBuilder: SourceGraphMutator {
                             }
                         }
                     }
+                }
+
+                // Handle constrained protocol extensions (e.g., `extension ProtocolA where Self: ProtocolB`).
+                // When the extension provides default implementations for members required by ProtocolB,
+                // create references from ProtocolB's requirements to the extension's implementations.
+                try referenceConstrainedExtensionImplementations(extensionDeclaration: extensionDeclaration)
+            }
+        }
+    }
+
+    /// For constrained protocol extensions like `extension ProtocolA where Self: ProtocolB`,
+    /// the extension's members may satisfy requirements of the constraining protocol (ProtocolB).
+    /// This method creates the necessary related references so that the conformance is properly recognized.
+    ///
+    /// The related reference is added from the extension's member to the protocol requirement,
+    /// which will then be inverted by ProtocolConformanceReferenceBuilder.
+    private func referenceConstrainedExtensionImplementations(extensionDeclaration: Declaration) throws {
+        // Find all protocols this extension is constrained by (via `where Self: ProtocolName`)
+        let constrainingProtocolRefs = extensionDeclaration.references.filter { $0.role == .genericRequirementType && $0.kind == .protocol }
+
+        for constrainingProtocolRef in constrainingProtocolRefs {
+            guard let constrainingProtocol = graph.declaration(withUsr: constrainingProtocolRef.usr) else { continue }
+
+            // For each member declared in the extension, check if it satisfies a requirement of the constraining protocol
+            for memberDeclaration in extensionDeclaration.declarations {
+                // Find matching requirement in the constraining protocol
+                let matchingRequirement = constrainingProtocol.declarations.first {
+                    $0.kind == memberDeclaration.kind && $0.name == memberDeclaration.name
+                }
+
+                guard let matchingRequirement else { continue }
+
+                // Create a related reference from the extension's member to the protocol requirement.
+                // This mimics the structure of a normal protocol conformance, where the conforming
+                // declaration has a related reference to the protocol member it implements.
+                // ProtocolConformanceReferenceBuilder will then invert this to create a reference
+                // from the protocol requirement to the extension's implementation.
+                for usr in matchingRequirement.usrs {
+                    let relatedReference = Reference(
+                        kind: matchingRequirement.kind,
+                        usr: usr,
+                        location: memberDeclaration.location,
+                        isRelated: true
+                    )
+                    relatedReference.name = matchingRequirement.name
+                    relatedReference.parent = memberDeclaration
+                    graph.add(relatedReference, from: memberDeclaration)
                 }
             }
         }

--- a/Tests/Fixtures/Sources/RetentionFixtures/testConstrainedProtocolExtensionSatisfiesProtocolRequirement.swift
+++ b/Tests/Fixtures/Sources/RetentionFixtures/testConstrainedProtocolExtensionSatisfiesProtocolRequirement.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+// When a protocol extension has a constraint requiring another protocol,
+// the extension's members should be recognized as satisfying the constraining protocol's requirements.
+
+public protocol FixtureProtocol1021A {
+    var value: String { get }
+}
+
+protocol FixtureProtocol1021B {}
+
+// This extension provides a default 'value' for types conforming to both protocols
+extension FixtureProtocol1021B where Self: FixtureProtocol1021A {
+    var value: String { "default" }
+}
+
+public func fixture1021Retainer() {
+    // Nested struct - the conformance is satisfied by the constrained extension
+    struct Conformer: FixtureProtocol1021A, FixtureProtocol1021B {}
+    let instance: FixtureProtocol1021A = Conformer()
+    _ = instance.value
+}

--- a/Tests/PeripheryTests/RetentionTest.swift
+++ b/Tests/PeripheryTests/RetentionTest.swift
@@ -755,6 +755,19 @@ final class RetentionTest: FixtureSourceGraphTestCase {
         }
     }
 
+    func testConstrainedProtocolExtensionSatisfiesProtocolRequirement() {
+        analyze(retainPublic: true) {
+            assertReferenced(.protocol("FixtureProtocol1021A")) {
+                self.assertReferenced(.varInstance("value"))
+            }
+            assertReferenced(.protocol("FixtureProtocol1021B"))
+            assertReferenced(.extensionProtocol("FixtureProtocol1021B")) {
+                // The extension's value satisfies FixtureProtocol1021A's requirement
+                self.assertReferenced(.varInstance("value"))
+            }
+        }
+    }
+
     func testDoesNotRetainProtocolMembersImplementedByExternalType() {
         analyze(retainPublic: true) {
             assertReferenced(.protocol("FixtureProtocol110")) {


### PR DESCRIPTION
When a protocol extension has a constraint (e.g., `extension A where Self: B`), recognize that its members can satisfy requirements of the constraining protocol.

Fixes #1021