### PR TITLE
Enable testRetainsOptionalProtocolMethodImplementedInSubclass

### DIFF
--- a/Tests/PeripheryTests/ObjcAccessibleRetentionTest.swift
+++ b/Tests/PeripheryTests/ObjcAccessibleRetentionTest.swift
@@ -4,12 +4,8 @@ import XCTest
 
 #if os(macOS)
     final class ObjcAccessibleRetentionTest: FixtureSourceGraphTestCase {
-        private let performKnownFailures = false
-
-        // https://github.com/apple/swift/issues/56327
-        func testRetainsOptionalProtocolMethodImplementedInSubclass() {
-            guard performKnownFailures else { return }
-
+        func testRetainsOptionalProtocolMethodImplementedInSubclass() throws {
+            try XCTSkipIf(Self.swiftVersion.version.isVersion(lessThan: "6.3"), "Requires Swift >= 6.3")
             analyze(retainPublic: true) {
                 assertReferenced(.class("FixtureClass125Base"))
                 assertReferenced(.class("FixtureClass125")) {


### PR DESCRIPTION
Fixed in https://github.com/swiftlang/swift/pull/86167. Resolves #902.