### PR TITLE
Mark code only used by #Preview macro as unused

### DIFF
--- a/Tests/XcodeTests/SwiftUIProject/SwiftUIProject/ContentView.swift
+++ b/Tests/XcodeTests/SwiftUIProject/SwiftUIProject/ContentView.swift
@@ -17,3 +17,24 @@ struct LibraryViewContent: LibraryContentProvider {
         LibraryItem(ContentView())
     }
 }
+
+// View referenced only from #Preview (mirrors ContentView referenced from PreviewProvider)
+struct DetailView: View {
+    var body: some View {
+        Text("Detail View")
+    }
+}
+
+// Nested type referenced only from #Preview - tests nested type handling
+struct PreviewHelpers {
+    struct NestedHelper {
+        static func makeText() -> String {
+            "Nested Helper Text"
+        }
+    }
+}
+
+#Preview {
+    DetailView()
+    Text(PreviewHelpers.NestedHelper.makeText())
+}

--- a/Tests/XcodeTests/SwiftUIProjectRetainPreviewsTest.swift
+++ b/Tests/XcodeTests/SwiftUIProjectRetainPreviewsTest.swift
@@ -1,0 +1,32 @@
+import Configuration
+@testable import TestShared
+
+final class SwiftUIProjectRetainPreviewsTest: XcodeSourceGraphTestCase {
+    override static func setUp() {
+        super.setUp()
+
+        let configuration = Configuration()
+        configuration.schemes = ["SwiftUIProject"]
+        configuration.retainSwiftUIPreviews = true
+
+        build(projectPath: SwiftUIProjectPath, configuration: configuration)
+        index(configuration: configuration)
+    }
+
+    func testRetainsPreviewProvider() {
+        // With flag enabled, PreviewProvider structs should be retained
+        assertReferenced(.struct("ContentView_Previews"))
+    }
+
+    func testRetainsPreviewMacroView() {
+        // With flag enabled, views referenced from #Preview should be retained
+        assertReferenced(.struct("DetailView"))
+    }
+
+    func testRetainsNestedTypeFromPreviewMacro() {
+        // With flag enabled, nested types referenced from #Preview should be retained
+        assertReferenced(.struct("PreviewHelpers")) {
+            self.assertReferenced(.struct("NestedHelper"))
+        }
+    }
+}

--- a/Tests/XcodeTests/SwiftUIProjectTest.swift
+++ b/Tests/XcodeTests/SwiftUIProjectTest.swift
@@ -33,4 +33,15 @@ final class SwiftUIProjectTest: XcodeSourceGraphTestCase {
     func testRetainsUIApplicationDelegateAdaptorReferencedType() {
         assertReferenced(.class("AppDelegate"))
     }
+
+    func testDoesNotRetainPreviewMacro() {
+        // Mirrors testDoesNotRetainPreviewProvider
+        // DetailView is only referenced from #Preview, so should not be retained
+        assertNotReferenced(.struct("DetailView"))
+    }
+
+    func testDoesNotRetainNestedTypeFromPreviewMacro() {
+        // Tests nested type references from #Preview
+        assertNotReferenced(.struct("PreviewHelpers"))
+    }
 }


### PR DESCRIPTION
 Fixes issue #1046 

This yields unused warnings  (unless `--retain-swift-ui-previews` option) on any code only used by `#Preview` code.
The newer `#Preview` macro works quite differently than the old PreviewProvider, so the algorithm to detect it is a bit more involved. I've created some tests, and I've also exercised it on a big code base with lots of code that's only used by its previews, that Periphery wasn't picking up on.