### PR TITLE
Fix IBAction methods with named parameters or no parameters marked as unused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ##### Bug Fixes
 
-- None.
+- Fix IBAction methods with named parameters or no parameters incorrectly marked as unused.
 
 ## 3.4.0 (2026-01-06)
 

--- a/Tests/PeripheryTests/InterfaceBuilderPropertyRetainerTest.swift
+++ b/Tests/PeripheryTests/InterfaceBuilderPropertyRetainerTest.swift
@@ -1,0 +1,83 @@
+import Foundation
+@testable import SourceGraph
+import XCTest
+
+/// Tests for InterfaceBuilderPropertyRetainer's Swift-to-Objective-C selector conversion.
+final class InterfaceBuilderPropertyRetainerTest: XCTestCase {
+    // MARK: - No Parameters
+
+    func testNoParameters() {
+        // func confirmTapped() → confirmTapped (no colon)
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("confirmTapped()"), "confirmTapped")
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("doSomething()"), "doSomething")
+    }
+
+    // MARK: - Unnamed First Parameter (using _)
+
+    func testUnnamedFirstParameter() {
+        // func click(_ sender: Any) → click:
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("click(_:)"), "click:")
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("handleTap(_:)"), "handleTap:")
+    }
+
+    // MARK: - Named First Parameter
+
+    func testNamedFirstParameter() {
+        // func colorTapped(sender: Any) → colorTappedWithSender:
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("colorTapped(sender:)"), "colorTappedWithSender:")
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("configure(model:)"), "configureWithModel:")
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("update(value:)"), "updateWithValue:")
+    }
+
+    // MARK: - Multiple Parameters with Unnamed First
+
+    func testMultipleParametersUnnamedFirst() {
+        // func handleTap(_:forEvent:) → handleTap:forEvent:
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("handleTap(_:forEvent:)"), "handleTap:forEvent:")
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("doSomething(_:withValue:andExtra:)"), "doSomething:withValue:andExtra:")
+    }
+
+    // MARK: - Multiple Parameters with Named First
+
+    func testMultipleParametersNamedFirst() {
+        // func configure(model:animated:) → configureWithModel:animated:
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("configure(model:animated:)"), "configureWithModel:animated:")
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("update(sender:completion:)"), "updateWithSender:completion:")
+    }
+
+    // MARK: - Preposition First Parameters (no "With" prefix)
+
+    func testPrepositionFirstParameter() {
+        // Prepositions are just capitalized, not prefixed with "With"
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("action(for:)"), "actionFor:")
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("action(with:)"), "actionWith:")
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("action(using:)"), "actionUsing:")
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("action(by:)"), "actionBy:")
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("action(to:)"), "actionTo:")
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("action(at:)"), "actionAt:")
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("action(in:)"), "actionIn:")
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("action(on:)"), "actionOn:")
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("action(from:)"), "actionFrom:")
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("action(into:)"), "actionInto:")
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("action(after:)"), "actionAfter:")
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("action(before:)"), "actionBefore:")
+    }
+
+    func testWithPrefixedFirstParameter() {
+        // Labels starting with "with" are just capitalized (no double "With")
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("action(withSender:)"), "actionWithSender:")
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("action(withValue:)"), "actionWithValue:")
+    }
+
+    // MARK: - Edge Cases
+
+    func testSingleLetterParameter() {
+        // func tap(x:) → tapWithX:
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("tap(x:)"), "tapWithX:")
+    }
+
+    func testMethodWithNoParentheses() {
+        // Should return as-is (shouldn't happen in practice, but handles edge case)
+        XCTAssertEqual(InterfaceBuilderPropertyRetainer.swiftNameToSelector("someProperty"), "someProperty")
+    }
+}

--- a/Tests/XcodeTests/UIKitProject/UIKitProject/XibViewController.swift
+++ b/Tests/XcodeTests/UIKitProject/UIKitProject/XibViewController.swift
@@ -14,9 +14,34 @@ class XibViewController: UIViewController {
         showAlert(title: "IBAction", message: "clickFromSubclass(_:) - Connected via Interface Builder")
     }
 
+    // IBAction with named first parameter (selector: clickWithNamedParamWithSender:)
+    @IBAction func clickWithNamedParam(sender: Any) {
+        showAlert(title: "IBAction", message: "clickWithNamedParam(sender:) - Connected via Interface Builder")
+    }
+
+    // IBAction with no parameters (selector: clickNoParams)
+    @IBAction func clickNoParams() {
+        showAlert(title: "IBAction", message: "clickNoParams() - Connected via Interface Builder")
+    }
+
+    // IBAction with preposition first parameter (selector: clickFor:)
+    @IBAction func click(for sender: Any) {
+        showAlert(title: "IBAction", message: "click(for:) - Connected via Interface Builder")
+    }
+
     // Unreferenced - not connected in XIB
     @IBAction func unusedAction(_ sender: Any) {
         showAlert(title: "Unused", message: "unusedAction(_:) - This should be reported as unused!")
+    }
+
+    // Unreferenced - IBAction with named param but not connected
+    @IBAction func unusedActionWithNamedParam(sender: Any) {
+        showAlert(title: "Unused", message: "unusedActionWithNamedParam(sender:) - This should be reported as unused!")
+    }
+
+    // Unreferenced - IBAction with no params but not connected
+    @IBAction func unusedActionNoParams() {
+        showAlert(title: "Unused", message: "unusedActionNoParams() - This should be reported as unused!")
     }
 
     // MARK: - IBInspectable

--- a/Tests/XcodeTests/UIKitProject/UIKitProject/XibViewController.xib
+++ b/Tests/XcodeTests/UIKitProject/UIKitProject/XibViewController.xib
@@ -40,6 +40,30 @@
                         <action selector="click:" destination="-1" eventType="touchUpInside" id="jLb-bl-k6b"/>
                     </connections>
                 </button>
+                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="btn-named-param">
+                    <rect key="frame" x="140" y="479" width="134" height="30"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <state key="normal" title="Named Param"/>
+                    <connections>
+                        <action selector="clickWithNamedParamWithSender:" destination="-1" eventType="touchUpInside" id="act-named-param"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="btn-no-params">
+                    <rect key="frame" x="160" y="519" width="94" height="30"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <state key="normal" title="No Params"/>
+                    <connections>
+                        <action selector="clickNoParams" destination="-1" eventType="touchUpInside" id="act-no-params"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="btn-preposition">
+                    <rect key="frame" x="160" y="559" width="94" height="30"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <state key="normal" title="Preposition"/>
+                    <connections>
+                        <action selector="clickFor:" destination="-1" eventType="touchUpInside" id="act-preposition"/>
+                    </connections>
+                </button>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="XibViewController" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ega-I7-Zu8">
                     <rect key="frame" x="139" y="410" width="136" height="21"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>

--- a/Tests/XcodeTests/UIKitProjectTest.swift
+++ b/Tests/XcodeTests/UIKitProjectTest.swift
@@ -30,11 +30,19 @@ final class UIKitProjectTest: XcodeSourceGraphTestCase {
             self.assertReferenced(.varInstance("button"))
             self.assertReferenced(.varInstance("controllerProperty"))
             self.assertReferenced(.functionMethodInstance("click(_:)"))
+            // IBAction with named first parameter
+            self.assertReferenced(.functionMethodInstance("clickWithNamedParam(sender:)"))
+            // IBAction with no parameters
+            self.assertReferenced(.functionMethodInstance("clickNoParams()"))
+            // IBAction with preposition first parameter
+            self.assertReferenced(.functionMethodInstance("click(for:)"))
             // Unreferenced - not connected in XIB
             self.assertNotReferenced(.varInstance("unusedOutlet"))
             self.assertNotReferenced(.functionMethodInstance("unusedAction(_:)"))
             self.assertNotReferenced(.functionMethodInstance("clickFromSubclass(_:)"))
             self.assertNotReferenced(.varInstance("unusedInspectable"))
+            self.assertNotReferenced(.functionMethodInstance("unusedActionWithNamedParam(sender:)"))
+            self.assertNotReferenced(.functionMethodInstance("unusedActionNoParams()"))
         }
         assertReferenced(.class("XibView")) {
             self.assertReferenced(.varInstance("viewProperty"))


### PR DESCRIPTION
The swiftNameToSelector function was incorrectly converting Swift method names to Objective-C selectors for IBAction methods:

- Named first parameter: `colorTapped(sender:)` should produce `colorTappedWithSender:` but was producing `colorTapped:`
- No parameters: `confirmTapped()` should produce `confirmTapped` but was producing `confirmTapped:`
- Preposition parameters: `click(for:)` should produce `clickFor:` (no "With" prefix)

The fix implements the full Swift-to-ObjC selector conversion rules, including handling of prepositions from Swift's PartsOfSpeech.def.

Resolves #1049