### PR TITLE
Detect more unused code in a single run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - The `--color` option now accepts one of `auto`, `always` and `never`. In `auto` mode, color is disabled for dumb terminals and non-TTYs.
 - Added detection of superfluous `// periphery:ignore` comments. A warning is now reported when an ignore comment is unnecessary because the declaration is actually used.
+- More unused code is now reported in a single scan, rather than requiring repeated remove-and-rescan cycles.
 
 ##### Bug Fixes
 

--- a/Sources/PeripheryKit/Results/CsvFormatter.swift
+++ b/Sources/PeripheryKit/Results/CsvFormatter.swift
@@ -34,7 +34,7 @@ final class CsvFormatter: OutputFormatter {
             case let .redundantProtocol(references, inherited):
                 for ref in references {
                     let line = format(
-                        kind: ref.kind.rawValue,
+                        kind: ref.declarationKind.rawValue,
                         name: ref.name,
                         modifiers: [],
                         attributes: [],

--- a/Sources/PeripheryKit/Results/JsonFormatter.swift
+++ b/Sources/PeripheryKit/Results/JsonFormatter.swift
@@ -35,7 +35,7 @@ final class JsonFormatter: OutputFormatter {
             case let .redundantProtocol(references, inherited):
                 for ref in references {
                     let object: [AnyHashable: Any] = [
-                        "kind": ref.kind.rawValue,
+                        "kind": ref.declarationKind.rawValue,
                         "name": ref.name ?? "",
                         "modifiers": [String](),
                         "attributes": [String](),

--- a/Sources/PeripheryKit/ScanResultBuilder.swift
+++ b/Sources/PeripheryKit/ScanResultBuilder.swift
@@ -86,7 +86,7 @@ public enum ScanResultBuilder {
         let references = graph.references(to: decl)
 
         for ref in references {
-            guard let parent = ref.parent else { continue }
+            guard ref.kind != .retained, let parent = ref.parent else { continue }
 
             // Check if the parent is not in the explicitly ignored set.
             // This covers deeply nested declarations because retainHierarchy marks

--- a/Sources/SourceGraph/Elements/Declaration.swift
+++ b/Sources/SourceGraph/Elements/Declaration.swift
@@ -254,10 +254,10 @@ public final class Declaration {
     }
 
     public var immediateInheritedTypeReferences: Set<Reference> {
-        let superclassReferences = related.filter { [.class, .struct, .protocol].contains($0.kind) }
+        let superclassReferences = related.filter { [.class, .struct, .protocol].contains($0.declarationKind) }
 
         // Inherited typealiases are References instead of a Related.
-        let typealiasReferences = references.filter { $0.kind == .typealias }
+        let typealiasReferences = references.filter { $0.declarationKind == .typealias }
         return superclassReferences.union(typealiasReferences)
     }
 
@@ -283,7 +283,7 @@ public final class Declaration {
     }
 
     public var relatedEquivalentReferences: [Reference] {
-        related.filter { $0.kind == kind && $0.name == name }
+        related.filter { $0.declarationKind == kind && $0.name == name }
     }
 
     public init(kind: Kind, usrs: Set<String>, location: Location) {

--- a/Sources/SourceGraph/Elements/Reference.swift
+++ b/Sources/SourceGraph/Elements/Reference.swift
@@ -1,4 +1,10 @@
 public final class Reference {
+    public enum Kind: String {
+        case normal
+        case related
+        case retained
+    }
+
     public enum Role: String {
         case varType
         case returnType
@@ -24,8 +30,8 @@ public final class Reference {
     }
 
     public let location: Location
-    public let kind: Declaration.Kind
-    public let isRelated: Bool
+    public let kind: Kind
+    public let declarationKind: Declaration.Kind
     public var name: String?
     public var parent: Declaration?
     public var references: Set<Reference> = []
@@ -34,12 +40,17 @@ public final class Reference {
 
     private let hashValueCache: Int
 
-    public init(kind: Declaration.Kind, usr: String, location: Location, isRelated: Bool = false) {
+    public init(
+        kind: Kind,
+        declarationKind: Declaration.Kind,
+        usr: String,
+        location: Location
+    ) {
         self.kind = kind
+        self.declarationKind = declarationKind
         self.usr = usr
-        self.isRelated = isRelated
         self.location = location
-        hashValueCache = [usr.hashValue, location.hashValue, isRelated.hashValue].hashValue
+        hashValueCache = [usr.hashValue, location.hashValue, kind.hashValue].hashValue
     }
 
     var descendentReferences: Set<Reference> {
@@ -55,21 +66,19 @@ extension Reference: Hashable {
 
 extension Reference: Equatable {
     public static func == (lhs: Reference, rhs: Reference) -> Bool {
-        lhs.usr == rhs.usr && lhs.location == rhs.location && lhs.isRelated == rhs.isRelated
+        lhs.usr == rhs.usr && lhs.location == rhs.location && lhs.kind == rhs.kind
     }
 }
 
 extension Reference: CustomStringConvertible {
     public var description: String {
-        let referenceType = isRelated ? "Related" : "Reference"
-
-        return "\(referenceType)(\(descriptionParts.joined(separator: ", ")))"
+        "Reference(\(descriptionParts.joined(separator: ", ")))"
     }
 
     var descriptionParts: [String] {
         let formattedName = name != nil ? "'\(name!)'" : "nil"
 
-        return [kind.rawValue, formattedName, "'\(usr)'", role.rawValue, location.shortDescription]
+        return [kind.rawValue, declarationKind.rawValue, formattedName, "'\(usr)'", role.rawValue, location.shortDescription]
     }
 }
 

--- a/Sources/SourceGraph/Mutators/AppIntentsRetainer.swift
+++ b/Sources/SourceGraph/Mutators/AppIntentsRetainer.swift
@@ -25,7 +25,7 @@ final class AppIntentsRetainer: SourceGraphMutator {
             .filter {
                 $0.related.contains {
                     self.graph.isExternal($0) &&
-                        $0.kind == .protocol &&
+                        $0.declarationKind == .protocol &&
                         $0.usr.hasPrefix(Self.appIntentsModuleUsrPrefix)
                 }
             }

--- a/Sources/SourceGraph/Mutators/CodingKeyEnumReferenceBuilder.swift
+++ b/Sources/SourceGraph/Mutators/CodingKeyEnumReferenceBuilder.swift
@@ -15,7 +15,7 @@ final class CodingKeyEnumReferenceBuilder: SourceGraphMutator {
             guard let parent = enumDeclaration.parent else { continue }
 
             let isCodingKey = graph.inheritedTypeReferences(of: enumDeclaration).contains {
-                $0.kind == .protocol && $0.name == "CodingKey"
+                $0.declarationKind == .protocol && $0.name == "CodingKey"
             }
 
             guard isCodingKey else { continue }
@@ -30,7 +30,12 @@ final class CodingKeyEnumReferenceBuilder: SourceGraphMutator {
             if graph.isCodable(parent) {
                 // Build a reference from the Codable type to the CodingKey enum.
                 for usr in enumDeclaration.usrs {
-                    let newReference = Reference(kind: .enum, usr: usr, location: enumDeclaration.location)
+                    let newReference = Reference(
+                        kind: .normal,
+                        declarationKind: .enum,
+                        usr: usr,
+                        location: enumDeclaration.location
+                    )
                     newReference.name = enumDeclaration.name
                     newReference.parent = parent
                     graph.add(newReference, from: parent)

--- a/Sources/SourceGraph/Mutators/ComplexPropertyAccessorReferenceBuilder.swift
+++ b/Sources/SourceGraph/Mutators/ComplexPropertyAccessorReferenceBuilder.swift
@@ -21,9 +21,12 @@ final class ComplexPropertyAccessorReferenceBuilder: SourceGraphMutator {
 
             if parent.isComplexProperty {
                 for usr in declaration.usrs {
-                    let reference = Reference(kind: declaration.kind,
-                                              usr: usr,
-                                              location: declaration.location)
+                    let reference = Reference(
+                        kind: .normal,
+                        declarationKind: declaration.kind,
+                        usr: usr,
+                        location: declaration.location
+                    )
                     reference.parent = parent
                     graph.add(reference, from: parent)
                 }

--- a/Sources/SourceGraph/Mutators/DefaultConstructorReferenceBuilder.swift
+++ b/Sources/SourceGraph/Mutators/DefaultConstructorReferenceBuilder.swift
@@ -26,9 +26,12 @@ final class DefaultConstructorReferenceBuilder: SourceGraphMutator {
         for constructor in defaultConstructors {
             if let parent = constructor.parent {
                 for usr in constructor.usrs {
-                    let reference = Reference(kind: .functionConstructor,
-                                              usr: usr,
-                                              location: parent.location)
+                    let reference = Reference(
+                        kind: .normal,
+                        declarationKind: .functionConstructor,
+                        usr: usr,
+                        location: parent.location
+                    )
                     reference.name = constructor.name
                     reference.parent = parent
                     graph.add(reference, from: parent)
@@ -41,9 +44,12 @@ final class DefaultConstructorReferenceBuilder: SourceGraphMutator {
         for destructor in graph.declarations(ofKind: .functionDestructor) {
             if let parent = destructor.parent {
                 for usr in destructor.usrs {
-                    let reference = Reference(kind: .functionDestructor,
-                                              usr: usr,
-                                              location: parent.location)
+                    let reference = Reference(
+                        kind: .normal,
+                        declarationKind: .functionDestructor,
+                        usr: usr,
+                        location: parent.location
+                    )
                     reference.name = destructor.name
                     reference.parent = parent
                     graph.add(reference, from: parent)

--- a/Sources/SourceGraph/Mutators/EnumCaseReferenceBuilder.swift
+++ b/Sources/SourceGraph/Mutators/EnumCaseReferenceBuilder.swift
@@ -13,7 +13,7 @@ final class EnumCaseReferenceBuilder: SourceGraphMutator {
     func mutate() {
         for enumDeclaration in graph.declarations(ofKind: .enum) {
             let isCodingKey = graph.inheritedTypeReferences(of: enumDeclaration).contains {
-                $0.kind == .protocol && $0.name == "CodingKey"
+                $0.declarationKind == .protocol && $0.name == "CodingKey"
             }
 
             if !isCodingKey, isRawRepresentable(enumDeclaration) {
@@ -21,7 +21,12 @@ final class EnumCaseReferenceBuilder: SourceGraphMutator {
 
                 for enumCase in enumCases {
                     for usr in enumCase.usrs {
-                        let reference = Reference(kind: .enumelement, usr: usr, location: enumCase.location)
+                        let reference = Reference(
+                            kind: .normal,
+                            declarationKind: .enumelement,
+                            usr: usr,
+                            location: enumCase.location
+                        )
                         reference.name = enumCase.name
                         reference.parent = enumDeclaration
                         graph.add(reference, from: enumDeclaration)
@@ -37,12 +42,12 @@ final class EnumCaseReferenceBuilder: SourceGraphMutator {
         // If the enum has a related struct it's very likely to be raw representable,
         // and thus is dynamic in nature.
 
-        if enumDeclaration.related.contains(where: { $0.kind == .struct }) {
+        if enumDeclaration.related.contains(where: { $0.declarationKind == .struct }) {
             return true
         }
 
         return graph.inheritedTypeReferences(of: enumDeclaration).contains {
-            $0.kind == .protocol && $0.name == "RawRepresentable"
+            $0.declarationKind == .protocol && $0.name == "RawRepresentable"
         }
     }
 }

--- a/Sources/SourceGraph/Mutators/ExternalOverrideRetainer.swift
+++ b/Sources/SourceGraph/Mutators/ExternalOverrideRetainer.swift
@@ -23,7 +23,7 @@ final class ExternalOverrideRetainer: SourceGraphMutator {
             var didIdentifyRelatedRef = false
 
             for relatedRef in decl.related {
-                if relatedRef.kind == decl.kind,
+                if relatedRef.declarationKind == decl.kind,
                    relatedRef.name == decl.name,
                    relatedRef.location == decl.location
                 {

--- a/Sources/SourceGraph/Mutators/ExternalTypeProtocolConformanceReferenceRemover.swift
+++ b/Sources/SourceGraph/Mutators/ExternalTypeProtocolConformanceReferenceRemover.swift
@@ -17,11 +17,11 @@ final class ExternalTypeProtocolConformanceReferenceRemover: SourceGraphMutator 
             guard try graph.extendedDeclaration(forExtension: extDecl) == nil else { continue }
 
             // Ensure the type is extended by local protocols.
-            let protocolDecls = extDecl.related.filter { $0.kind == .protocol }.map { graph.declaration(withUsr: $0.usr) }
+            let protocolDecls = extDecl.related.filter { $0.declarationKind == .protocol }.map { graph.declaration(withUsr: $0.usr) }
             guard !protocolDecls.isEmpty else { continue }
 
             // Find all related references that may be protocol members.
-            let relatedRefs = extDecl.related.filter(\.kind.isProtocolMemberKind)
+            let relatedRefs = extDecl.related.filter(\.declarationKind.isProtocolMemberKind)
 
             for relatedRef in relatedRefs {
                 // Ensure the relatedDecl is a member of a protocol.

--- a/Sources/SourceGraph/Mutators/GenericClassAndStructConstructorReferenceBuilder.swift
+++ b/Sources/SourceGraph/Mutators/GenericClassAndStructConstructorReferenceBuilder.swift
@@ -22,9 +22,12 @@ final class GenericClassAndStructConstructorReferenceBuilder: SourceGraphMutator
 
             for constructor in constructors {
                 for usr in constructor.usrs {
-                    let reference = Reference(kind: .functionConstructor,
-                                              usr: usr,
-                                              location: declaration.location)
+                    let reference = Reference(
+                        kind: .normal,
+                        declarationKind: .functionConstructor,
+                        usr: usr,
+                        location: declaration.location
+                    )
                     reference.name = constructor.name
                     reference.parent = declaration
                     graph.add(reference, from: declaration)

--- a/Sources/SourceGraph/Mutators/InheritedImplicitInitializerReferenceBuilder.swift
+++ b/Sources/SourceGraph/Mutators/InheritedImplicitInitializerReferenceBuilder.swift
@@ -25,7 +25,7 @@ final class InheritedImplicitInitializerReferenceBuilder: SourceGraphMutator {
             for explicitInit in explicitInitializers {
                 // Check if this initializer has related references to implicit initializers in subclasses
                 for relatedRef in explicitInit.related {
-                    guard relatedRef.kind == .functionConstructor else { continue }
+                    guard relatedRef.declarationKind == .functionConstructor else { continue }
 
                     // Find the declaration this related reference points to
                     guard let implicitInit = graph.declaration(withUsr: relatedRef.usr),
@@ -36,10 +36,10 @@ final class InheritedImplicitInitializerReferenceBuilder: SourceGraphMutator {
                     // Add the inverse reference: implicit init -> explicit init
                     for usr in explicitInit.usrs {
                         let reference = Reference(
-                            kind: .functionConstructor,
+                            kind: .related,
+                            declarationKind: .functionConstructor,
                             usr: usr,
-                            location: implicitInit.location,
-                            isRelated: true
+                            location: implicitInit.location
                         )
                         reference.name = explicitInit.name
                         reference.parent = implicitInit

--- a/Sources/SourceGraph/Mutators/ProtocolExtensionReferenceBuilder.swift
+++ b/Sources/SourceGraph/Mutators/ProtocolExtensionReferenceBuilder.swift
@@ -21,7 +21,12 @@ final class ProtocolExtensionReferenceBuilder: SourceGraphMutator {
             // First, create a reference from each protocol to the extension.
             if let extendedProtocol = try graph.extendedDeclaration(forExtension: extensionDeclaration) {
                 for usr in extensionDeclaration.usrs {
-                    let reference = Reference(kind: .extensionProtocol, usr: usr, location: extendedProtocol.location)
+                    let reference = Reference(
+                        kind: .normal,
+                        declarationKind: .extensionProtocol,
+                        usr: usr,
+                        location: extendedProtocol.location
+                    )
                     reference.name = extendedProtocol.name
                     reference.parent = extendedProtocol
                     graph.add(reference, from: extendedProtocol)
@@ -39,14 +44,24 @@ final class ProtocolExtensionReferenceBuilder: SourceGraphMutator {
                     for reference in graph.references(to: memberDeclaration) {
                         if let parentDeclaration = reference.parent {
                             for usr in extensionDeclaration.usrs {
-                                let extensionReference = Reference(kind: .extensionProtocol, usr: usr, location: reference.location)
+                                let extensionReference = Reference(
+                                    kind: .normal,
+                                    declarationKind: .extensionProtocol,
+                                    usr: usr,
+                                    location: reference.location
+                                )
                                 extensionReference.name = extensionDeclaration.name
                                 extensionReference.parent = parentDeclaration
                                 graph.add(extensionReference, from: parentDeclaration)
                             }
 
                             for usr in extendedProtocol.usrs {
-                                let protocolReference = Reference(kind: .protocol, usr: usr, location: reference.location)
+                                let protocolReference = Reference(
+                                    kind: .normal,
+                                    declarationKind: .protocol,
+                                    usr: usr,
+                                    location: reference.location
+                                )
                                 protocolReference.name = extendedProtocol.name
                                 protocolReference.parent = parentDeclaration
                                 graph.add(protocolReference, from: parentDeclaration)
@@ -71,7 +86,7 @@ final class ProtocolExtensionReferenceBuilder: SourceGraphMutator {
     /// which will then be inverted by ProtocolConformanceReferenceBuilder.
     private func referenceConstrainedExtensionImplementations(extensionDeclaration: Declaration) throws {
         // Find all protocols this extension is constrained by (via `where Self: ProtocolName`)
-        let constrainingProtocolRefs = extensionDeclaration.references.filter { $0.role == .genericRequirementType && $0.kind == .protocol }
+        let constrainingProtocolRefs = extensionDeclaration.references.filter { $0.role == .genericRequirementType && $0.declarationKind == .protocol }
 
         for constrainingProtocolRef in constrainingProtocolRefs {
             guard let constrainingProtocol = graph.declaration(withUsr: constrainingProtocolRef.usr) else { continue }
@@ -92,10 +107,10 @@ final class ProtocolExtensionReferenceBuilder: SourceGraphMutator {
                 // from the protocol requirement to the extension's implementation.
                 for usr in matchingRequirement.usrs {
                     let relatedReference = Reference(
-                        kind: matchingRequirement.kind,
+                        kind: .related,
+                        declarationKind: matchingRequirement.kind,
                         usr: usr,
-                        location: memberDeclaration.location,
-                        isRelated: true
+                        location: memberDeclaration.location
                     )
                     relatedReference.name = matchingRequirement.name
                     relatedReference.parent = memberDeclaration

--- a/Sources/SourceGraph/Mutators/StructImplicitInitializerReferenceBuilder.swift
+++ b/Sources/SourceGraph/Mutators/StructImplicitInitializerReferenceBuilder.swift
@@ -36,7 +36,12 @@ final class StructImplicitInitializerReferenceBuilder: SourceGraphMutator {
 
                     for decl in [propertyDecl, setterDecl] {
                         for usr in decl.usrs {
-                            let ref = Reference(kind: decl.kind, usr: usr, location: implicitInitDecl.location)
+                            let ref = Reference(
+                                kind: .normal,
+                                declarationKind: decl.kind,
+                                usr: usr,
+                                location: implicitInitDecl.location
+                            )
                             ref.name = decl.name
                             ref.parent = implicitInitDecl
                             graph.add(ref, from: implicitInitDecl)

--- a/Sources/SourceGraph/Mutators/SwiftUIRetainer.swift
+++ b/Sources/SourceGraph/Mutators/SwiftUIRetainer.swift
@@ -32,7 +32,7 @@ final class SwiftUIRetainer: SourceGraphMutator {
             .lazy
             .filter {
                 $0.related.contains {
-                    self.graph.isExternal($0) && $0.kind == .protocol && names.contains($0.name ?? "")
+                    self.graph.isExternal($0) && $0.declarationKind == .protocol && names.contains($0.name ?? "")
                 }
             }
             .forEach { graph.markRetained($0) }
@@ -46,7 +46,7 @@ final class SwiftUIRetainer: SourceGraphMutator {
             .filter { $0.kind == .varInstance }
             .filter {
                 $0.references.contains {
-                    ($0.kind == .struct || $0.kind == .enum) && Self.applicationDelegateAdaptorStructNames.contains($0.name ?? "")
+                    ($0.declarationKind == .struct || $0.declarationKind == .enum) && Self.applicationDelegateAdaptorStructNames.contains($0.name ?? "")
                 }
             }
             .forEach { graph.markRetained($0) }

--- a/Sources/SourceGraph/Mutators/UnusedImportMarker.swift
+++ b/Sources/SourceGraph/Mutators/UnusedImportMarker.swift
@@ -103,7 +103,7 @@ final class UnusedImportMarker: SourceGraphMutator {
     /// Identifies any modules that extend the given declaration reference, as they may provide
     /// members and conformances that are required for compilation.
     private func modulesExtending(_ ref: Reference) -> Set<String> {
-        guard ref.kind.isExtendableKind else { return [] }
+        guard ref.declarationKind.isExtendableKind else { return [] }
 
         if let modules = extendedDeclCache[ref.usr] {
             return modules
@@ -112,7 +112,7 @@ final class UnusedImportMarker: SourceGraphMutator {
         let modules: Set<String> = graph.references(to: ref.usr)
             .flatMapSet {
                 guard let parent = $0.parent,
-                      parent.kind == ref.kind.extensionKind,
+                      parent.kind == ref.declarationKind.extensionKind,
                       parent.name == ref.name
                 else { return [] }
 

--- a/Sources/SourceGraph/Mutators/UnusedParameterRetainer.swift
+++ b/Sources/SourceGraph/Mutators/UnusedParameterRetainer.swift
@@ -23,7 +23,7 @@ final class UnusedParameterRetainer: SourceGraphMutator {
 
             for protoFuncDecl in protoFuncDecls {
                 let relatedFuncDecls = protoFuncDecl.related
-                    .filter(\.kind.isFunctionKind)
+                    .filter(\.declarationKind.isFunctionKind)
                     .compactMapSet { graph.declaration(withUsr: $0.usr) }
                 let extFuncDecls = relatedFuncDecls.filter { $0.parent?.kind.isExtensionKind ?? false }
                 let conformingDecls = relatedFuncDecls.subtracting(extFuncDecls)

--- a/Sources/SourceGraph/Mutators/XCTestRetainer.swift
+++ b/Sources/SourceGraph/Mutators/XCTestRetainer.swift
@@ -16,7 +16,7 @@ final class XCTestRetainer: SourceGraphMutator {
             $0.related.contains {
                 guard let name = $0.name else { return false }
 
-                return $0.kind == .class && self.testCaseClassNames.contains(name)
+                return $0.declarationKind == .class && self.testCaseClassNames.contains(name)
             }
         }
 

--- a/Tests/Fixtures/Sources/RetentionFixtures/testConformanceToExternalProtocolIsRetained.swift
+++ b/Tests/Fixtures/Sources/RetentionFixtures/testConformanceToExternalProtocolIsRetained.swift
@@ -1,7 +1,13 @@
 import Foundation
 
-public class FixtureClass55: Equatable {
-    public static func == (lhs: FixtureClass55, rhs: FixtureClass55) -> Bool {
+class FixtureClass55: Equatable {
+    static func == (lhs: FixtureClass55, rhs: FixtureClass55) -> Bool {
         return true
+    }
+}
+
+public class FixtureClass55Retainer {
+    public func retain() {
+        _ = FixtureClass55.self
     }
 }

--- a/Tests/PeripheryTests/RetentionTest.swift
+++ b/Tests/PeripheryTests/RetentionTest.swift
@@ -120,7 +120,7 @@ final class RetentionTest: FixtureSourceGraphTestCase {
     }
 
     func testConformanceToExternalProtocolIsRetained() {
-        analyze {
+        analyze(retainPublic: true) {
             // Retained because it's a method from an external declaration (in this case, Equatable)
             assertReferenced(.class("FixtureClass55")) {
                 self.assertReferenced(.functionOperatorInfix("==(_:_:)"))


### PR DESCRIPTION
Changes retention behavior such that the parent declaration holds most references, rather than `SourceGraph.retainedDeclarations`. This prevents strong retention of declarations that are actually unused due to an unused ancestor.