### PR TITLE
Exclude declarations ignored by `// periphery:ignore:all` from superfluous ignore commend detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ##### Bug Fixes
 
-- None.
+- Exclude declarations ignored by a file-level `// periphery:ignore:all` comment from superfluous ignore commend detection.
 
 ## 3.5.0 (2026-02-11)
 

--- a/Sources/BUILD.bazel
+++ b/Sources/BUILD.bazel
@@ -46,6 +46,7 @@ swift_library(
     srcs = [
         "SourceGraph/Elements/Accessibility.swift",
         "SourceGraph/Elements/AssetReference.swift",
+        "SourceGraph/Elements/CommandIgnoreKind.swift",
         "SourceGraph/Elements/CommentCommand.swift",
         "SourceGraph/Elements/Declaration.swift",
         "SourceGraph/Elements/DeclarationAttribute.swift",

--- a/Sources/SourceGraph/Elements/CommandIgnoreKind.swift
+++ b/Sources/SourceGraph/Elements/CommandIgnoreKind.swift
@@ -1,0 +1,8 @@
+public enum CommandIgnoreKind {
+    /// Ignored by a `// periphery:ignore` comment on the declaration itself,
+    /// or by being a descendant/parameter of such a declaration.
+    case declaration
+
+    /// Ignored by a file-level `// periphery:ignore:all` comment.
+    case file
+}

--- a/Sources/SourceGraph/SourceGraph.swift
+++ b/Sources/SourceGraph/SourceGraph.swift
@@ -20,7 +20,7 @@ public final class SourceGraph {
     public private(set) var unusedModuleImports: Set<Declaration> = []
     public private(set) var assignOnlyProperties: Set<Declaration> = []
     public private(set) var extensions: [Declaration: Set<Declaration>] = [:]
-    public private(set) var explicitlyIgnoredDeclarations: Set<Declaration> = []
+    public private(set) var commandIgnoredDeclarations: [Declaration: CommandIgnoreKind] = [:]
     public private(set) var functionsWithIgnoredParameters: Set<Declaration> = []
 
     private var indexedModules: Set<String> = []
@@ -91,8 +91,8 @@ public final class SourceGraph {
         _ = ignoredDeclarations.insert(declaration)
     }
 
-    public func markExplicitlyIgnored(_ declaration: Declaration) {
-        _ = explicitlyIgnoredDeclarations.insert(declaration)
+    public func markCommandIgnored(_ declaration: Declaration, kind: CommandIgnoreKind) {
+        commandIgnoredDeclarations[declaration] = kind
     }
 
     public func markHasIgnoredParameters(_ declaration: Declaration) {

--- a/Tests/PeripheryTests/RetentionTest.swift
+++ b/Tests/PeripheryTests/RetentionTest.swift
@@ -1157,13 +1157,16 @@ final class RetentionTest: FixtureSourceGraphTestCase {
     }
 
     func testIgnoreAllComment() {
-        analyze(retainPublic: true) {
+        analyze(retainPublic: false) {
             assertReferenced(.class("Fixture115")) {
                 self.assertReferenced(.functionMethodInstance("someFunc(param:)")) {
                     self.assertReferenced(.varParameter("param"))
                 }
             }
             assertReferenced(.class("Fixture116"))
+
+            assertNotSuperfluousIgnoreCommand(.class("Fixture115"))
+            assertNotSuperfluousIgnoreCommand(.class("Fixture116"))
         }
     }
 


### PR DESCRIPTION
Resolves #1071 