### PR TITLE
Fix false positive redundant public accessibility for same-type extension requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ##### Bug Fixes
 
+- Fix false positive redundant public accessibility for types used in same-type generic requirements on extensions, e.g. `extension SomeProtocol where Self == MyType`.
 - Exclude declarations ignored by a file-level `// periphery:ignore:all` comment from superfluous ignore commend detection.
 
 ## 3.5.0 (2026-02-11)

--- a/Sources/SyntaxAnalysis/DeclarationSyntaxVisitor.swift
+++ b/Sources/SyntaxAnalysis/DeclarationSyntaxVisitor.swift
@@ -482,6 +482,10 @@ public final class DeclarationSyntaxVisitor: PeripherySyntaxVisitor {
         return clause.requirements.reduce(into: .init()) { result, requirement in
             if let conformanceRequirementType = requirement.requirement.as(ConformanceRequirementSyntax.self) {
                 result.formUnion(typeSyntaxInspector.typeLocations(for: conformanceRequirementType.rightType))
+            } else if let sameTypeRequirement = requirement.requirement.as(SameTypeRequirementSyntax.self) {
+                if case let .type(rightType) = sameTypeRequirement.rightType {
+                    result.formUnion(typeSyntaxInspector.typeLocations(for: rightType))
+                }
             }
         }
     }

--- a/Tests/AccessibilityTests/AccessibilityProject/Sources/MainTarget/main.swift
+++ b/Tests/AccessibilityTests/AccessibilityProject/Sources/MainTarget/main.swift
@@ -79,3 +79,6 @@ inlinableFunction()
 // Associated types
 _ = PublicInheritedAssociatedTypeClass().items
 _ = PublicInheritedAssociatedTypeDefaultTypeClass().items
+
+// Extension with same-type generic requirement
+takeExtensionSameTypeGenericRequirement(.defaultInstance)

--- a/Tests/AccessibilityTests/AccessibilityProject/Sources/TargetA/PublicTypeUsedAsExtensionSameTypeGenericRequirement.swift
+++ b/Tests/AccessibilityTests/AccessibilityProject/Sources/TargetA/PublicTypeUsedAsExtensionSameTypeGenericRequirement.swift
@@ -1,0 +1,15 @@
+public protocol PublicTypeUsedAsExtensionSameTypeGenericRequirement_Protocol {}
+
+public struct PublicTypeUsedAsExtensionSameTypeGenericRequirement: PublicTypeUsedAsExtensionSameTypeGenericRequirement_Protocol {
+    public init() {}
+}
+
+extension PublicTypeUsedAsExtensionSameTypeGenericRequirement_Protocol where Self == PublicTypeUsedAsExtensionSameTypeGenericRequirement {
+    public static var defaultInstance: Self {
+        PublicTypeUsedAsExtensionSameTypeGenericRequirement()
+    }
+}
+
+public func takeExtensionSameTypeGenericRequirement<T: PublicTypeUsedAsExtensionSameTypeGenericRequirement_Protocol>(_ value: T) {
+    _ = value
+}

--- a/Tests/AccessibilityTests/RedundantPublicAccessibilityTest.swift
+++ b/Tests/AccessibilityTests/RedundantPublicAccessibilityTest.swift
@@ -331,6 +331,12 @@ final class RedundantPublicAccessibilityTest: SPMSourceGraphTestCase {
         assertNotRedundantPublicAccessibility(.protocol("PublicInheritedAssociatedTypeDefaultType"))
     }
 
+    func testPublicTypeUsedAsExtensionSameTypeGenericRequirement() {
+        index()
+
+        assertNotRedundantPublicAccessibility(.struct("PublicTypeUsedAsExtensionSameTypeGenericRequirement"))
+    }
+
     func testPublicComparableOperatorFunction() {
         index()
 


### PR DESCRIPTION
Types used in same-type generic requirements on extensions (e.g. `extension SomeProtocol where Self == MyType`) were incorrectly reported as having redundant public accessibility. Two issues contributed to this:

1. The syntax visitor did not extract type locations from SameTypeRequirementSyntax in generic where clauses, so the reference role was never set to genericRequirementType.

2. Extensions without an explicit `public` modifier were not considered to expose types in their generic constraints, even when they contained public members.

Resolves #1069