### PR TITLE
Fix stray ")" in global_indexstore path in generated BUILD.bazel

### DIFF
--- a/Sources/ProjectDrivers/BazelProjectDriver.swift
+++ b/Sources/ProjectDrivers/BazelProjectDriver.swift
@@ -86,7 +86,7 @@ public final class BazelProjectDriver: ProjectDriver {
         let buildPath = outputPath.appending("BUILD.bazel")
         let deps = try queryTargets().joined(separator: ",\n")
         let globalIndexStoreValue = configuration.bazelIndexStore.map {
-            "\"\($0.makeAbsolute()))\""
+            "\"\($0.makeAbsolute())\""
         } ?? "None"
         let buildFileContents = """
         load("@periphery//bazel:rules.bzl", "scan")


### PR DESCRIPTION
## Summary

`BazelProjectDriver.swift` line 89 has an extra literal `)` in the string interpolation that constructs the `global_indexstore` value for the generated `BUILD.bazel`:

```swift
"\"\($0.makeAbsolute()))\""
//                      ^ stray ")" — literal character, not part of \(...)
```

This produces invalid Bazel syntax in `/var/tmp/periphery_bazel/BUILD.bazel`:

```python
global_indexstore = "/path/to/indexstore)",  # broken — stray ")"
```

instead of:

```python
global_indexstore = "/path/to/indexstore",   # correct
```

## Fix

Remove the extra `)` so the interpolation reads `"\"\($0.makeAbsolute())\""`.

## How to reproduce

Run periphery with `--bazel --bazel-index-store /any/path` and inspect the generated `/var/tmp/periphery_bazel/BUILD.bazel` — the `global_indexstore` value will contain a trailing `)` inside the quotes.