### PR TITLE
Discover SwiftPM interface builder files in target sources

### DIFF
--- a/Sources/ProjectDrivers/SPMProjectDriver.swift
+++ b/Sources/ProjectDrivers/SPMProjectDriver.swift
@@ -10,6 +10,7 @@ public final class SPMProjectDriver {
     private let pkg: SPM.Package
     private let configuration: Configuration
     private let logger: Logger
+    private let interfaceBuilderFileExtensions: Set<String> = ["storyboard", "xib"]
 
     public convenience init(configuration: Configuration, shell: Shell, logger: Logger) throws {
         if !configuration.schemes.isEmpty {
@@ -80,22 +81,47 @@ extension SPMProjectDriver: ProjectDriver {
 
         for target in description.targets {
             let targetPath = pkg.path.appending(target.path)
+            xibFiles.formUnion(interfaceBuilderFiles(in: targetPath))
 
             guard let resources = target.resources else { continue }
 
             for resource in resources {
-                // Resource.path is always a single file path
                 let resourceFilePath = FilePath(resource.path)
                 let resourcePath: FilePath = resourceFilePath.isAbsolute
                     ? resourceFilePath
                     : targetPath.appending(resource.path)
 
-                // Check if the resource path exists and is a xib/storyboard file
                 guard resourcePath.exists else { continue }
-                guard let ext = resourcePath.extension?.lowercased(), ["xib", "storyboard"].contains(ext) else { continue }
+                guard let ext = resourcePath.extension?.lowercased(), interfaceBuilderFileExtensions.contains(ext) else { continue }
 
                 xibFiles.insert(resourcePath)
             }
+        }
+
+        return xibFiles
+    }
+
+    private func interfaceBuilderFiles(in targetPath: FilePath) -> Set<FilePath> {
+        guard targetPath.exists else { return [] }
+        guard let enumerator = FileManager.default.enumerator(
+            at: targetPath.url,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+
+        var xibFiles: Set<FilePath> = []
+
+        for case let url as URL in enumerator {
+            guard let isRegularFile = try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile,
+                  isRegularFile == true
+            else { continue }
+
+            let path = FilePath(url.path).lexicallyNormalized()
+            guard let ext = path.extension?.lowercased(), interfaceBuilderFileExtensions.contains(ext) else { continue }
+
+            xibFiles.insert(path)
         }
 
         return xibFiles

--- a/Tests/SPMTests/SPMProjectMacOS/Sources/SPMProjectMacOSKit/Resources/SPMXibViewController.xib
+++ b/Tests/SPMTests/SPMProjectMacOS/Sources/SPMProjectMacOSKit/Resources/SPMXibViewController.xib
@@ -30,6 +30,7 @@
                     </buttonCell>
                     <connections>
                         <action selector="buttonTapped:" target="-2" id="jLb-bl-k6b"/>
+                        <action selector="privateExtensionTapped:" target="-2" id="private-extension-action"/>
                     </connections>
                 </button>
             </subviews>

--- a/Tests/SPMTests/SPMProjectMacOS/Sources/SPMProjectMacOSKit/SPMXibViewController.swift
+++ b/Tests/SPMTests/SPMProjectMacOS/Sources/SPMProjectMacOSKit/SPMXibViewController.swift
@@ -5,7 +5,7 @@ public final class SPMXibViewController: NSViewController {
 
     @IBOutlet var button: NSButton!
 
-    @IBAction func buttonTapped(_: Any) {
+    @IBAction private func buttonTapped(_: Any) {
         showAlert(title: "SPMXibViewController", message: "buttonTapped(_:) action triggered!")
     }
 
@@ -15,7 +15,7 @@ public final class SPMXibViewController: NSViewController {
 
     @IBOutlet var unusedMacOutlet: NSTextField!
 
-    @IBAction func unusedMacAction(_: Any) {
+    @IBAction private func unusedMacAction(_: Any) {
         showAlert(title: "SPMXibViewController", message: "unusedMacAction(_:) - this should be reported as unused!")
     }
 
@@ -34,5 +34,15 @@ public final class SPMXibViewController: NSViewController {
         alert.alertStyle = .informational
         alert.addButton(withTitle: "OK")
         alert.runModal()
+    }
+}
+
+private extension SPMXibViewController {
+    @IBAction func privateExtensionTapped(_: Any) {
+        showAlert(title: "SPMXibViewController", message: "privateExtensionTapped(_:) action triggered!")
+    }
+
+    @IBAction func unusedPrivateExtensionAction(_: Any) {
+        showAlert(title: "SPMXibViewController", message: "unusedPrivateExtensionAction(_:) - this should be reported as unused!")
     }
 }

--- a/Tests/SPMTests/SPMProjectMacOSTest.swift
+++ b/Tests/SPMTests/SPMProjectMacOSTest.swift
@@ -1,5 +1,8 @@
 #if os(macOS)
     import Configuration
+    import Foundation
+    import ProjectDrivers
+    import SystemPackage
     @testable import TestShared
     import XCTest
 
@@ -15,12 +18,71 @@
             assertReferenced(.class("SPMXibViewController")) {
                 // Referenced via XIB (connected)
                 self.assertReferenced(.functionMethodInstance("buttonTapped(_:)"))
+                self.assertReferenced(.functionMethodInstance("privateExtensionTapped(_:)"))
                 self.assertReferenced(.varInstance("button"))
                 self.assertReferenced(.varInstance("borderWidth"))
                 // Unreferenced - not connected in XIB
                 self.assertNotReferenced(.varInstance("unusedMacOutlet"))
                 self.assertNotReferenced(.functionMethodInstance("unusedMacAction(_:)"))
+                self.assertNotReferenced(.functionMethodInstance("unusedPrivateExtensionAction(_:)"))
                 self.assertNotReferenced(.varInstance("unusedMacInspectable"))
+            }
+        }
+    }
+
+    final class SPMProjectMacOSFilesystemIBDiscoveryTest: SPMSourceGraphTestCase {
+        override static func setUp() {
+            super.setUp()
+            build(projectPath: SPMProjectMacOSPath)
+        }
+
+        func testDiscoversInterfaceBuilderFilesWithoutDeclaredResources() throws {
+            let manifestJSON = """
+            {
+              "targets": [
+                {
+                  "name": "SPMProjectMacOSKit",
+                  "type": "regular",
+                  "path": "Sources/SPMProjectMacOSKit"
+                },
+                {
+                  "name": "Frontend",
+                  "type": "executable",
+                  "path": "Sources/Frontend"
+                }
+              ]
+            }
+            """
+
+            let manifestURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension("json")
+            try manifestJSON.write(to: manifestURL, atomically: true, encoding: .utf8)
+            defer {
+                try? FileManager.default.removeItem(at: manifestURL)
+            }
+
+            let planConfiguration = Configuration()
+            planConfiguration.jsonPackageManifestPath = FilePath(manifestURL.path)
+
+            try SPMProjectMacOSPath.chdir {
+                let driver = try SPMProjectDriver(
+                    configuration: planConfiguration,
+                    shell: Self.shell,
+                    logger: Self.logger
+                )
+                Self.plan = try driver.plan(logger: Self.logger.contextualized(with: "index"))
+            }
+
+            let expectedXibPath = SPMProjectMacOSPath
+                .appending("Sources/SPMProjectMacOSKit/Resources/SPMXibViewController.xib")
+            XCTAssertTrue(Self.plan.xibPaths.contains(expectedXibPath))
+
+            index(configuration: Configuration())
+
+            assertReferenced(.class("SPMXibViewController")) {
+                self.assertReferenced(.functionMethodInstance("buttonTapped(_:)"))
+                self.assertReferenced(.functionMethodInstance("privateExtensionTapped(_:)"))
             }
         }
     }


### PR DESCRIPTION
## Summary
Fix SwiftPM Interface Builder discovery by scanning target directories for XIB and storyboard files, even when they are not declared as package resources.
Add regression coverage for private `IBAction` methods and the fallback filesystem discovery path.

Made with [Cursor](https://cursor.com)