### PR TITLE
Treat equivalent overridden declarations as used

### DIFF
--- a/Sources/BUILD.bazel
+++ b/Sources/BUILD.bazel
@@ -68,6 +68,7 @@ swift_library(
         "SourceGraph/Mutators/DynamicMemberRetainer.swift",
         "SourceGraph/Mutators/EntryPointAttributeRetainer.swift",
         "SourceGraph/Mutators/EnumCaseReferenceBuilder.swift",
+        "SourceGraph/Mutators/EquivalentDeclarationMarker.swift",
         "SourceGraph/Mutators/ExtensionReferenceBuilder.swift",
         "SourceGraph/Mutators/ExternalOverrideRetainer.swift",
         "SourceGraph/Mutators/ExternalTypeProtocolConformanceReferenceRemover.swift",

--- a/Sources/SourceGraph/Mutators/EquivalentDeclarationMarker.swift
+++ b/Sources/SourceGraph/Mutators/EquivalentDeclarationMarker.swift
@@ -1,0 +1,42 @@
+import Configuration
+import Foundation
+import Shared
+import SystemPackage
+
+/// Treats multiple generated declarations that map back to the same source declaration via
+/// `periphery:override` as equivalent. If any equivalent declaration is used, the source
+/// declaration is used and the others should not be reported as unused.
+final class EquivalentDeclarationMarker: SourceGraphMutator {
+    private struct Key: Hashable {
+        let path: FilePath
+        let line: Int
+        let column: Int
+        let kind: String
+        let name: String
+    }
+
+    private let graph: SourceGraph
+
+    required init(graph: SourceGraph, configuration _: Configuration, swiftVersion _: SwiftVersion) {
+        self.graph = graph
+    }
+
+    func mutate() {
+        let overriddenDeclarations: [(key: Key, declaration: Declaration)] = graph.allDeclarations.compactMap { declaration in
+            guard let (path, line, column) = declaration.commentCommands.locationOverride else {
+                return nil
+            }
+
+            let kind = declaration.commentCommands.kindOverride ?? declaration.kind.rawValue
+            return (key: Key(path: path, line: line, column: column, kind: kind, name: declaration.name), declaration: declaration)
+        }
+        let declarationsByKey = Dictionary(grouping: overriddenDeclarations, by: \.key)
+
+        for groupedDeclarations in declarationsByKey.values {
+            let declarations = groupedDeclarations.map(\.declaration)
+            guard declarations.count > 1 else { continue }
+            guard declarations.contains(where: graph.isUsed) else { continue }
+            declarations.forEach { graph.markUsed($0) }
+        }
+    }
+}

--- a/Sources/SourceGraph/SourceGraphMutatorRunner.swift
+++ b/Sources/SourceGraph/SourceGraphMutatorRunner.swift
@@ -50,6 +50,7 @@ public final class SourceGraphMutatorRunner {
         AssignOnlyPropertyReferenceEliminator.self,
 
         UsedDeclarationMarker.self,
+        EquivalentDeclarationMarker.self,
         RedundantProtocolMarker.self,
     ]
 

--- a/Tests/Fixtures/Package.swift
+++ b/Tests/Fixtures/Package.swift
@@ -18,6 +18,12 @@ var targets: [PackageDescription.Target] = [
         name: "CrossModuleRetentionSupportFixtures"
     ),
     .target(
+        name: "GeneratedLocalizedStringPrimaryFixtures"
+    ),
+    .target(
+        name: "GeneratedLocalizedStringDuplicateFixtures"
+    ),
+    .target(
         name: "UnusedImportFixtureA",
         path: "Sources/UnusedImportFixtures/A"
     ),

--- a/Tests/Fixtures/Sources/GeneratedLocalizedStringDuplicateFixtures/GeneratedLocalizedStringFixtures.swift
+++ b/Tests/Fixtures/Sources/GeneratedLocalizedStringDuplicateFixtures/GeneratedLocalizedStringFixtures.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+public enum GeneratedAssets {
+    public static let strings = GeneratedStrings()
+}
+
+public final class GeneratedStrings {
+    public let prompt = PromptStrings()
+    public let verification = VerificationStrings()
+    public let nsfwSetting = NSFWSettingStrings()
+}
+
+public final class PromptStrings {
+    /// periphery:override kind="localized string" location="Fixtures/Generated.strings:9:1"
+    public var title: String { "prompt.title" }
+}
+
+public final class VerificationStrings {
+    /// periphery:override kind="localized string" location="Fixtures/Generated.strings:11:1"
+    public var title: String { "verification.title" }
+}
+
+public final class NSFWSettingStrings {
+    public let updated = UpdatedStrings()
+}
+
+public final class UpdatedStrings {
+    /// periphery:override kind="localized string" location="Fixtures/Generated.strings:57:1"
+    public var toast: String { "nsfwSetting.updated.toast" }
+}

--- a/Tests/Fixtures/Sources/GeneratedLocalizedStringPrimaryFixtures/GeneratedLocalizedStringFixtures.swift
+++ b/Tests/Fixtures/Sources/GeneratedLocalizedStringPrimaryFixtures/GeneratedLocalizedStringFixtures.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+public enum GeneratedAssets {
+    public static let strings = GeneratedStrings()
+}
+
+public final class GeneratedStrings {
+    public let prompt = PromptStrings()
+    public let verification = VerificationStrings()
+    public let nsfwSetting = NSFWSettingStrings()
+}
+
+public final class PromptStrings {
+    /// periphery:override kind="localized string" location="Fixtures/Generated.strings:9:1"
+    public var title: String { "prompt.title" }
+}
+
+public final class VerificationStrings {
+    /// periphery:override kind="localized string" location="Fixtures/Generated.strings:11:1"
+    public var title: String { "verification.title" }
+}
+
+public final class NSFWSettingStrings {
+    public let updated = UpdatedStrings()
+}
+
+public final class UpdatedStrings {
+    /// periphery:override kind="localized string" location="Fixtures/Generated.strings:57:1"
+    public var toast: String { "nsfwSetting.updated.toast" }
+}

--- a/Tests/Fixtures/Sources/GeneratedLocalizedStringPrimaryFixtures/UseGeneratedLocalizedStrings.swift
+++ b/Tests/Fixtures/Sources/GeneratedLocalizedStringPrimaryFixtures/UseGeneratedLocalizedStrings.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public func useGeneratedLocalizedStrings() {
+    _ = GeneratedAssets.strings.prompt.title
+    _ = GeneratedAssets.strings.verification.title
+    _ = GeneratedAssets.strings.nsfwSetting.updated.toast
+}

--- a/Tests/PeripheryTests/CrossModuleRetentionTest.swift
+++ b/Tests/PeripheryTests/CrossModuleRetentionTest.swift
@@ -19,4 +19,14 @@ final class CrossModuleRetentionTest: SPMSourceGraphTestCase {
             self.assertReferenced(.class("FixtureClass129"))
         }
     }
+
+    func testCrossModuleLocalizedStringOverridesAreTreatedAsSingleSourceDeclaration() {
+        assertNoUnusedResult(.varInstance("title", line: 15), inModule: "GeneratedLocalizedStringPrimaryFixtures")
+        assertNoUnusedResult(.varInstance("title", line: 20), inModule: "GeneratedLocalizedStringPrimaryFixtures")
+        assertNoUnusedResult(.varInstance("toast", line: 29), inModule: "GeneratedLocalizedStringPrimaryFixtures")
+
+        assertNoUnusedResult(.varInstance("title", line: 15), inModule: "GeneratedLocalizedStringDuplicateFixtures")
+        assertNoUnusedResult(.varInstance("title", line: 20), inModule: "GeneratedLocalizedStringDuplicateFixtures")
+        assertNoUnusedResult(.varInstance("toast", line: 29), inModule: "GeneratedLocalizedStringDuplicateFixtures")
+    }
 }

--- a/Tests/Shared/SourceGraphTestCase.swift
+++ b/Tests/Shared/SourceGraphTestCase.swift
@@ -109,6 +109,26 @@ open class SourceGraphTestCase: XCTestCase {
         }
     }
 
+    func assertNoUnusedResult(_ description: DeclarationDescription, inModule module: String? = nil, file: StaticString = #file, line: UInt = #line) {
+        let hasUnusedResult = Self.results.contains { result in
+            guard case .unused = result.annotation else { return false }
+            let declaration = result.declaration
+            guard declaration.kind == description.kind, declaration.name == description.name else { return false }
+            if let module, !declaration.location.file.modules.contains(module) {
+                return false
+            }
+            if let declarationLine = description.line, declaration.location.line != declarationLine {
+                return false
+            }
+            return true
+        }
+
+        if hasUnusedResult {
+            let scopeSuffix = module.map { " in module '\($0)'" } ?? ""
+            XCTFail("Expected declaration to not have an unused result\(scopeSuffix): \(description)", file: file, line: line)
+        }
+    }
+
     func assertRedundantProtocol(
         _ name: String,
         implementedBy conformances: DeclarationDescription...,


### PR DESCRIPTION
# Summary

- Treat declarations that share the same `periphery:override` source location, kind, and name as equivalent.
- Mark all equivalent declarations as used when any one of them is used, which avoids false positives for generated localized string accessors duplicated across modules.
- Add regression fixtures and a cross-module test covering duplicated generated localized string wrappers.

# Testing

- `swift test --filter CrossModuleRetentionTest/testCrossModuleLocalizedStringOverridesAreTreatedAsSingleSourceDeclaration`