### PR TITLE
Add Equatable and Hashable property retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ##### Enhancements
 
-- None.
+- Added the `--retain-equatable-properties` and `--retain-hashable-properties` options to retain all properties on `Equatable` and `Hashable` types.
 
 ##### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
     - [Unused Imports](#unused-imports)
     - [Objective-C](#objective-c)
     - [Codable](#codable)
+    - [Equatable and Hashable](#equatable-and-hashable)
     - [XCTestCase](#xctestcase)
     - [Interface Builder](#interface-builder)
     - [SPI (System Programming Interface)](#spi-system-programming-interface)
@@ -311,6 +312,10 @@ Alternatively, the `--retain-objc-annotated` option can be used to only retain d
 Swift synthesizes additional code for `Codable` types that is not visible to Periphery and can result in false positives for properties not directly referenced from non-synthesized code. If your project contains many such types, you can retain all properties on `Codable` types with `--retain-codable-properties`. Alternatively, you can retain properties only on `Encodable` types with `--retain-encodable-properties`.
 
 If `Codable` conformance is declared by a protocol in an external module not scanned by Periphery, you can instruct Periphery to identify the protocols as `Codable` with `--external-codable-protocols "ExternalProtocol"`.
+
+### Equatable and Hashable
+
+Swift synthesizes additional code for `Equatable` and `Hashable` types that is not visible to Periphery and can result in false positives for properties not directly referenced from non-synthesized code. If your project contains many such types, you can retain all properties on `Equatable` types with `--retain-equatable-properties`, or all properties on `Hashable` types with `--retain-hashable-properties`. The `Equatable` option also retains properties on `Hashable` types because `Hashable` refines `Equatable`.
 
 ### XCTestCase
 

--- a/Sources/BUILD.bazel
+++ b/Sources/BUILD.bazel
@@ -68,6 +68,7 @@ swift_library(
         "SourceGraph/Mutators/DynamicMemberRetainer.swift",
         "SourceGraph/Mutators/EntryPointAttributeRetainer.swift",
         "SourceGraph/Mutators/EnumCaseReferenceBuilder.swift",
+        "SourceGraph/Mutators/EquatableHashablePropertyRetainer.swift",
         "SourceGraph/Mutators/ExtensionReferenceBuilder.swift",
         "SourceGraph/Mutators/ExternalOverrideRetainer.swift",
         "SourceGraph/Mutators/ExternalTypeProtocolConformanceReferenceRemover.swift",

--- a/Sources/Configuration/Configuration.swift
+++ b/Sources/Configuration/Configuration.swift
@@ -95,6 +95,12 @@ public final class Configuration {
     @Setting(key: "retain_encodable_properties", defaultValue: false)
     public var retainEncodableProperties: Bool
 
+    @Setting(key: "retain_equatable_properties", defaultValue: false)
+    public var retainEquatableProperties: Bool
+
+    @Setting(key: "retain_hashable_properties", defaultValue: false)
+    public var retainHashableProperties: Bool
+
     @Setting(key: "verbose", defaultValue: false)
     public var verbose: Bool
 
@@ -223,7 +229,8 @@ public final class Configuration {
         $externalEncodableProtocols, $externalCodableProtocols, $externalTestCaseClasses, $verbose, $quiet, $color,
         $disableUpdateCheck, $strict, $indexStorePath,
         $skipBuild, $skipSchemesValidation, $cleanBuild, $buildArguments, $xcodeListArguments, $relativeResults,
-        $jsonPackageManifestPath, $retainCodableProperties, $retainEncodableProperties, $baseline, $writeBaseline,
+        $jsonPackageManifestPath, $retainCodableProperties, $retainEncodableProperties, $retainEquatableProperties,
+        $retainHashableProperties, $baseline, $writeBaseline,
         $writeResults, $genericProjectConfig, $bazel, $bazelFilter, $bazelIndexStore, $bazelCheckVisibility,
     ]
 

--- a/Sources/Frontend/Commands/ScanCommand.swift
+++ b/Sources/Frontend/Commands/ScanCommand.swift
@@ -105,6 +105,12 @@ struct ScanCommand: ParsableCommand {
     @Flag(help: "Retain properties on Encodable types only")
     var retainEncodableProperties: Bool = defaultConfiguration.$retainEncodableProperties.defaultValue
 
+    @Flag(help: "Retain properties on Equatable types, including Hashable types")
+    var retainEquatableProperties: Bool = defaultConfiguration.$retainEquatableProperties.defaultValue
+
+    @Flag(help: "Retain properties on Hashable types")
+    var retainHashableProperties: Bool = defaultConfiguration.$retainHashableProperties.defaultValue
+
     @Flag(help: "Clean existing build artifacts before building")
     var cleanBuild: Bool = defaultConfiguration.$cleanBuild.defaultValue
 
@@ -214,6 +220,8 @@ struct ScanCommand: ParsableCommand {
         configuration.apply(\.$relativeResults, relativeResults)
         configuration.apply(\.$retainCodableProperties, retainCodableProperties)
         configuration.apply(\.$retainEncodableProperties, retainEncodableProperties)
+        configuration.apply(\.$retainEquatableProperties, retainEquatableProperties)
+        configuration.apply(\.$retainHashableProperties, retainHashableProperties)
         configuration.apply(\.$jsonPackageManifestPath, jsonPackageManifestPath)
         configuration.apply(\.$baseline, baseline)
         configuration.apply(\.$writeBaseline, writeBaseline)

--- a/Sources/SourceGraph/Mutators/EquatableHashablePropertyRetainer.swift
+++ b/Sources/SourceGraph/Mutators/EquatableHashablePropertyRetainer.swift
@@ -1,0 +1,37 @@
+import Configuration
+import Foundation
+import Shared
+
+final class EquatableHashablePropertyRetainer: SourceGraphMutator {
+    private let graph: SourceGraph
+    private let configuration: Configuration
+
+    required init(graph: SourceGraph, configuration: Configuration, swiftVersion _: SwiftVersion) {
+        self.graph = graph
+        self.configuration = configuration
+    }
+
+    func mutate() {
+        for decl in graph.declarations(ofKinds: Declaration.Kind.discreteConformableKinds) {
+            guard decl.kind != .class, shouldRetainProperties(of: decl) else { continue }
+
+            for decl in decl.declarations {
+                guard decl.kind == .varInstance else { continue }
+
+                graph.markRetained(decl)
+            }
+        }
+    }
+
+    private func shouldRetainProperties(of decl: Declaration) -> Bool {
+        if configuration.retainEquatableProperties, graph.isEquatable(decl) {
+            return true
+        }
+
+        if configuration.retainHashableProperties, graph.isHashable(decl) {
+            return true
+        }
+
+        return false
+    }
+}

--- a/Sources/SourceGraph/SourceGraph.swift
+++ b/Sources/SourceGraph/SourceGraph.swift
@@ -403,4 +403,18 @@ public final class SourceGraph {
             [.protocol, .typealias].contains($0.declarationKind) && encodableTypes.contains($0.name)
         }
     }
+
+    func isEquatable(_ decl: Declaration) -> Bool {
+        let equatableTypes = ["Equatable", "Hashable"]
+
+        return inheritedTypeReferences(of: decl).contains {
+            [.protocol, .typealias].contains($0.declarationKind) && equatableTypes.contains($0.name)
+        }
+    }
+
+    func isHashable(_ decl: Declaration) -> Bool {
+        inheritedTypeReferences(of: decl).contains {
+            [.protocol, .typealias].contains($0.declarationKind) && $0.name == "Hashable"
+        }
+    }
 }

--- a/Sources/SourceGraph/SourceGraphMutatorRunner.swift
+++ b/Sources/SourceGraph/SourceGraphMutatorRunner.swift
@@ -44,6 +44,7 @@ public final class SourceGraphMutatorRunner {
         PropertyWrapperRetainer.self,
         ResultBuilderRetainer.self,
         CodablePropertyRetainer.self,
+        EquatableHashablePropertyRetainer.self,
         ExternalOverrideRetainer.self,
 
         AncestralReferenceEliminator.self,

--- a/Tests/Fixtures/Sources/RetentionFixtures/testRetainsEquatableProperties.swift
+++ b/Tests/Fixtures/Sources/RetentionFixtures/testRetainsEquatableProperties.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public struct FixtureStruct222: Equatable {
+    let unused: Int
+
+    init(unused: Int) {
+        self.unused = unused
+    }
+}
+
+public struct FixtureStruct223: Hashable {
+    let unused: Int
+
+    init(unused: Int) {
+        self.unused = unused
+    }
+}
+
+public final class FixtureClass222: Equatable {
+    let unused: Int
+
+    init(unused: Int) {
+        self.unused = unused
+    }
+
+    public static func == (lhs: FixtureClass222, rhs: FixtureClass222) -> Bool {
+        true
+    }
+}

--- a/Tests/Fixtures/Sources/RetentionFixtures/testRetainsHashableProperties.swift
+++ b/Tests/Fixtures/Sources/RetentionFixtures/testRetainsHashableProperties.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct FixtureStruct224: Hashable {
+    let unused: Int
+
+    init(unused: Int) {
+        self.unused = unused
+    }
+}

--- a/Tests/PeripheryTests/RetentionTest.swift
+++ b/Tests/PeripheryTests/RetentionTest.swift
@@ -1002,6 +1002,64 @@ final class RetentionTest: FixtureSourceGraphTestCase {
         }
     }
 
+    func testRetainsEquatableProperties() {
+        analyze(
+            retainPublic: true,
+            retainEquatableProperties: false,
+            retainAssignOnlyProperties: false
+        ) {
+            assertReferenced(.struct("FixtureStruct222")) {
+                self.assertNotReferenced(.functionConstructor("init(unused:)"))
+                self.assertAssignOnlyProperty(.varInstance("unused"))
+            }
+        }
+
+        analyze(
+            retainPublic: true,
+            retainEquatableProperties: true
+        ) {
+            assertReferenced(.struct("FixtureStruct222")) {
+                self.assertNotReferenced(.functionConstructor("init(unused:)"))
+                self.assertReferenced(.varInstance("unused"))
+                self.assertNotAssignOnlyProperty(.varInstance("unused"))
+            }
+
+            assertReferenced(.struct("FixtureStruct223")) {
+                self.assertNotReferenced(.functionConstructor("init(unused:)"))
+                self.assertReferenced(.varInstance("unused"))
+                self.assertNotAssignOnlyProperty(.varInstance("unused"))
+            }
+
+            assertReferenced(.class("FixtureClass222")) {
+                self.assertAssignOnlyProperty(.varInstance("unused"))
+            }
+        }
+    }
+
+    func testRetainsHashableProperties() {
+        analyze(
+            retainPublic: true,
+            retainHashableProperties: false,
+            retainAssignOnlyProperties: false
+        ) {
+            assertReferenced(.struct("FixtureStruct224")) {
+                self.assertNotReferenced(.functionConstructor("init(unused:)"))
+                self.assertAssignOnlyProperty(.varInstance("unused"))
+            }
+        }
+
+        analyze(
+            retainPublic: true,
+            retainHashableProperties: true
+        ) {
+            assertReferenced(.struct("FixtureStruct224")) {
+                self.assertNotReferenced(.functionConstructor("init(unused:)"))
+                self.assertReferenced(.varInstance("unused"))
+                self.assertNotAssignOnlyProperty(.varInstance("unused"))
+            }
+        }
+    }
+
     func testRetainsFilesOption() {
         analyze(retainFiles: [testFixturePath.string]) {
             assertReferenced(.class("FixtureClass100"))

--- a/Tests/Shared/FixtureSourceGraphTestCase.swift
+++ b/Tests/Shared/FixtureSourceGraphTestCase.swift
@@ -20,6 +20,8 @@ class FixtureSourceGraphTestCase: SPMSourceGraphTestCase {
         superfluousIgnoreComments: Bool = true,
         retainCodableProperties: Bool = false,
         retainEncodableProperties: Bool = false,
+        retainEquatableProperties: Bool = false,
+        retainHashableProperties: Bool = false,
         retainUnusedProtocolFuncParams: Bool = false,
         retainAssignOnlyProperties: Bool = false,
         retainAssignOnlyPropertyTypes: [String] = [],
@@ -40,6 +42,8 @@ class FixtureSourceGraphTestCase: SPMSourceGraphTestCase {
         configuration.externalCodableProtocols = externalCodableProtocols
         configuration.retainCodableProperties = retainCodableProperties
         configuration.retainEncodableProperties = retainEncodableProperties
+        configuration.retainEquatableProperties = retainEquatableProperties
+        configuration.retainHashableProperties = retainHashableProperties
         configuration.retainUnusedProtocolFuncParams = retainUnusedProtocolFuncParams
         configuration.retainAssignOnlyPropertyTypes = retainAssignOnlyPropertyTypes
         configuration.externalTestCaseClasses = externalTestCaseClasses


### PR DESCRIPTION
## Summary

- Add `retain_equatable_properties` and `retain_hashable_properties` configuration options and CLI flags.
- Retain stored properties for value types that conform to `Equatable` or `Hashable`, including inherited protocol conformances.
- Add fixtures and retention tests covering both options.

## Motivation

Swift can synthesize `Equatable` and `Hashable` conformances from stored properties without producing explicit references in index data. That can make properties appear unused even though changing or removing them changes synthesized equality or hashing behavior.

This keeps the behavior opt-in, similar to the existing `retain_codable_properties` setting, so projects can choose the broader retention behavior when synthesized protocol requirements are part of their API surface.

Fixes #869.
Fixes #1028.
Related to #721.

## Testing

- `swift test --filter "RetentionTest/testRetains"`
- `swift test`
- `swiftformat --quiet --strict .`
- `swiftlint lint --quiet --strict`
- `bazelisk run //bazel/dev:buildifier.check`
- `git diff --check`
