### PR TITLE
Skip unresolvable subproject file references instead of throwing

### DIFF
--- a/Sources/XcodeSupport/XcodeProject.swift
+++ b/Sources/XcodeSupport/XcodeProject.swift
@@ -65,7 +65,7 @@ public final class XcodeProject: XcodeProjectlike {
         if !path.components.contains("Pods.xcodeproj") {
             subProjects = try xcodeProject.pbxproj.fileReferences
                 .filter { $0.path?.hasSuffix(".xcodeproj") ?? false }
-                .compactMap { try $0.fullPath(sourceRoot: sourceRoot.string) }
+                .compactMap { try? $0.fullPath(sourceRoot: sourceRoot.string) }
                 .compactMap {
                     let projectPath = FilePath($0)
 


### PR DESCRIPTION
When an Xcode project contains a file reference to a subproject that can't be resolved (e.g. the subproject isn't checked out, or the reference is stale), `XcodeProject` currently throws and the whole scan aborts.

This changes the behavior to skip the unresolvable reference and continue the scan. Hitting this required nothing exotic — a workspace where one team's subproject wasn't present locally was enough to make Periphery unusable on the rest of the project.
