### PR TITLE
Retain properties read only via their synthesized projected value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ##### Bug Fixes
 
 - Follow embedded bundle and plugin edges transitively in the generated Bazel scan rule so custom Bazel queries can avoid building incorrectly transitioned targets while still analyzing extension- and plugin-reachable code.
+- Retain a property that is read only via its synthesized projected value, e.g. a SwiftUI `@State` property passed as `$property`, so it is no longer falsely reported unused. Properties that are never read remain reported.
 
 ## 3.7.4 (2026-04-26)
 

--- a/Sources/BUILD.bazel
+++ b/Sources/BUILD.bazel
@@ -83,6 +83,7 @@ swift_library(
         "SourceGraph/Mutators/RedundantExplicitPublicAccessibilityMarker.swift",
         "SourceGraph/Mutators/RedundantProtocolMarker.swift",
         "SourceGraph/Mutators/ResultBuilderRetainer.swift",
+        "SourceGraph/Mutators/StateProjectedValueRetainer.swift",
         "SourceGraph/Mutators/StringInterpolationAppendInterpolationRetainer.swift",
         "SourceGraph/Mutators/StructImplicitInitializerReferenceBuilder.swift",
         "SourceGraph/Mutators/SwiftTestingRetainer.swift",

--- a/Sources/SourceGraph/Mutators/StateProjectedValueRetainer.swift
+++ b/Sources/SourceGraph/Mutators/StateProjectedValueRetainer.swift
@@ -1,0 +1,75 @@
+import Configuration
+import Foundation
+import Shared
+
+/// Retains user properties that are referenced only via a synthesized sibling member.
+///
+/// SwiftUI's `@State`, `@Binding`, and similar property wrappers cause the compiler to
+/// synthesize sibling members for a property `foo`, including a projected value `$foo` (e.g. a
+/// `SwiftUI.Binding`) and backing storage `_foo`/`__foo`. These synthesized members are marked
+/// `implicit` in the index store and are children of the same type as `foo`.
+///
+/// When `foo` is read only through its projected value — e.g. `Child(value: $foo)` — the index
+/// records a reference to the synthesized `$foo` member, not to the user-declared `foo`. As a
+/// result `foo` has no incoming references of its own and is falsely reported unused.
+///
+/// This mutator detects the case by matching the synthesized projected value to its user
+/// property by name (`$foo` ↔ `foo`) and, only when that projected value is actually referenced
+/// at a use site, retaining the user property. A property that is never read at all has no
+/// referenced projected value and therefore remains eligible to be reported unused.
+final class StateProjectedValueRetainer: SourceGraphMutator {
+    private let graph: SourceGraph
+    private static let projectedValuePrefix = "$"
+
+    required init(graph: SourceGraph, configuration _: Configuration, swiftVersion _: SwiftVersion) {
+        self.graph = graph
+    }
+
+    func mutate() {
+        for typeDecl in graph.declarations(ofKinds: [.class, .struct, .enum]) {
+            let instanceProperties = typeDecl.declarations.filter { $0.kind == .varInstance }
+            guard !instanceProperties.isEmpty else { continue }
+
+            let userPropertiesByName = instanceProperties
+                .filter { !$0.isImplicit }
+                .reduce(into: [String: Declaration]()) { result, decl in
+                    result[decl.name] = decl
+                }
+
+            guard !userPropertiesByName.isEmpty else { continue }
+
+            for synthesized in instanceProperties where synthesized.isImplicit {
+                guard let userProperty = userProperty(for: synthesized.name, in: userPropertiesByName),
+                      isReferencedAtUseSite(synthesized)
+                else { continue }
+
+                graph.markRetained(userProperty)
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func userProperty(for synthesizedName: String, in userProperties: [String: Declaration]) -> Declaration? {
+        guard synthesizedName.hasPrefix(Self.projectedValuePrefix) else { return nil }
+
+        let baseName = String(synthesizedName.dropFirst(Self.projectedValuePrefix.count))
+
+        guard !baseName.isEmpty else { return nil }
+
+        return userProperties[baseName]
+    }
+
+    /// A synthesized member is auto-retained by the indexer simply for being implicit, so its
+    /// retained status alone doesn't indicate use. It is only genuinely used when the index
+    /// records an incoming reference originating from a non-implicit declaration, i.e. an actual
+    /// use site in user code, as opposed to the implicit cross-references the compiler synthesizes
+    /// between a property's own backing members.
+    private func isReferencedAtUseSite(_ declaration: Declaration) -> Bool {
+        graph.references(to: declaration).contains { reference in
+            guard reference.kind != .retained, let parent = reference.parent else { return false }
+
+            return !parent.isImplicit
+        }
+    }
+}

--- a/Sources/SourceGraph/SourceGraphMutatorRunner.swift
+++ b/Sources/SourceGraph/SourceGraphMutatorRunner.swift
@@ -42,6 +42,7 @@ public final class SourceGraphMutatorRunner {
         AppIntentsRetainer.self,
         StringInterpolationAppendInterpolationRetainer.self,
         PropertyWrapperRetainer.self,
+        StateProjectedValueRetainer.self,
         ResultBuilderRetainer.self,
         CodablePropertyRetainer.self,
         EquatableHashablePropertyRetainer.self,

--- a/Tests/Fixtures/Package.swift
+++ b/Tests/Fixtures/Package.swift
@@ -75,6 +75,9 @@ targets.append(contentsOf: [
     ),
     .target(
         name: "AppIntentsRetentionFixtures"
+    ),
+    .target(
+        name: "SwiftUIStateRetentionFixtures"
     )
 ])
 #endif

--- a/Tests/Fixtures/Sources/SwiftUIStateRetentionFixtures/StateProjectedValueChildView.swift
+++ b/Tests/Fixtures/Sources/SwiftUIStateRetentionFixtures/StateProjectedValueChildView.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+struct StateProjectedValueChildView: View {
+    @Binding var model: StateModel
+
+    var body: some View {
+        Text(model.title)
+    }
+}

--- a/Tests/Fixtures/Sources/SwiftUIStateRetentionFixtures/testRetainsStateReadOnlyViaProjectedValue.swift
+++ b/Tests/Fixtures/Sources/SwiftUIStateRetentionFixtures/testRetainsStateReadOnlyViaProjectedValue.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+public struct StateProjectedValueParentView: View {
+    @State private var projectedOnlyState = StateModel()
+    @State private var neverReadState = StateModel()
+
+    public init() {}
+
+    public var body: some View {
+        StateProjectedValueChildView(model: $projectedOnlyState)
+    }
+}
+
+final class StateModel: ObservableObject {
+    var title = ""
+}

--- a/Tests/PeripheryTests/SwiftUIStateRetentionTest.swift
+++ b/Tests/PeripheryTests/SwiftUIStateRetentionTest.swift
@@ -1,0 +1,22 @@
+#if os(macOS)
+    @testable import TestShared
+    import XCTest
+
+    final class SwiftUIStateRetentionTest: FixtureSourceGraphTestCase {
+        func testRetainsStateReadOnlyViaProjectedValue() {
+            let additionalFilesToIndex = [
+                FixturesProjectPath.appending("Sources/SwiftUIStateRetentionFixtures/StateProjectedValueChildView.swift"),
+            ]
+
+            analyze(retainPublic: true, additionalFilesToIndex: additionalFilesToIndex) {
+                assertReferenced(.struct("StateProjectedValueParentView")) {
+                    // Read only via its projected value '$projectedOnlyState', passed as a
+                    // labeled argument to a child view in another file.
+                    self.assertReferenced(.varInstance("projectedOnlyState"))
+                    // Never read at all; the fix must not retain this.
+                    self.assertNotReferenced(.varInstance("neverReadState"))
+                }
+            }
+        }
+    }
+#endif


### PR DESCRIPTION
### The bug

A property read **only** through its synthesized projected value is falsely reported as unused. The most common case is a SwiftUI `@State` property passed to a child view as a binding:

```swift
struct ParentView: View {
    @State private var settings = Settings()   // reported unused

    var body: some View {
        ChildView(settings: $settings)         // read only via $settings
    }
}
```

Property wrappers such as `@State` and `@Binding` cause the compiler to synthesize sibling members for a property `foo`: a projected value `$foo` (a `SwiftUI.Binding`) plus backing storage `_foo`/`__foo`. In the index store these synthesized members are marked `implicit` and are children of the same type as `foo`.

When the property is read only via `$foo`, the index records the read as a reference to the synthesized `$foo` member rather than to the user-declared `foo`. As a result `foo` has no incoming references of its own and is reported unused.

### Which toolchains are affected

This manifests on the **Xcode 27 / Swift 6.4 `@State` macro form**, where the synthesized members appear in the index as distinct `implicit` `$foo`/`_foo`/`__foo` declarations and the `$foo` read does not produce a reference to the user property.

On the **Xcode 26 / earlier property-wrapper form** the index instead records a direct `read` of the user property at the `$foo` use site, so that form was never affected. The fix is a no-op there.

### The fix

A new `StateProjectedValueRetainer` mutator matches each synthesized projected value to its user property by name (`$foo` → `foo`) and retains the user property — but only when the projected value is **actually referenced at a use site**.

The precision gate matters: the implicit backing members the compiler cross-references among themselves would otherwise make any wrapped property look used. The mutator therefore requires an incoming reference whose `kind` is not `.retained` (i.e. not the synthetic self-reference the indexer adds for implicit declarations) and whose parent declaration is itself non-implicit (a real use site in user code, not the compiler's internal plumbing between a property's own backing members).

Consequently a property that is **never read at all** has no referenced projected value and is still reported unused.

### Tests

Adds a cross-file fixture and test (`SwiftUIStateRetentionTest`) asserting both halves of the behavior:

- a `@State` property read only via `$property` (passed to a child view in another file) is **retained**, and
- a sibling `@State` property that is never read is **still reported unused**.

This dual assertion demonstrates the fix is targeted and does not blanket-retain wrapped properties.
