### PR TITLE
Retain public accessibility for witnesses of external protocol requirements

### DIFF
--- a/Sources/SourceGraph/Mutators/RedundantExplicitPublicAccessibilityMarker.swift
+++ b/Sources/SourceGraph/Mutators/RedundantExplicitPublicAccessibilityMarker.swift
@@ -58,6 +58,11 @@ final class RedundantExplicitPublicAccessibilityMarker: SourceGraphMutator {
 
     private func validateExtension(_ decl: Declaration) throws {
         if decl.accessibility.isExplicitly(.public) {
+            // A public member declared in this extension may be the witness for a requirement of an
+            // external public protocol (e.g. `Identifiable`). Such a witness must remain public,
+            // otherwise compilation fails, so the extension's public accessibility is not redundant.
+            guard !decl.declarations.contains(where: isWitnessForExternalProtocolRequirement) else { return }
+
             // If the extended kind is already marked as having redundant public accessibility, then this extension
             // must also have redundant accessibility.
             if let extendedDecl = try graph.extendedDeclaration(forExtension: decl),
@@ -65,6 +70,21 @@ final class RedundantExplicitPublicAccessibilityMarker: SourceGraphMutator {
             {
                 mark(decl)
             }
+        }
+    }
+
+    /// A declaration is the witness for an external protocol requirement when it has a related
+    /// reference to a protocol member whose USR does not resolve to a declaration in the source
+    /// graph. The unresolved USR indicates the requirement belongs to an external protocol (such as
+    /// the standard library's `Identifiable`), which is necessarily public. A witness for a public
+    /// protocol requirement must be declared with matching public accessibility, so its explicit
+    /// public modifier is never redundant.
+    private func isWitnessForExternalProtocolRequirement(_ decl: Declaration) -> Bool {
+        decl.related.contains { reference in
+            reference.kind == .related &&
+                reference.declarationKind.isProtocolMemberConformingKind &&
+                reference.name == decl.name &&
+                graph.declaration(withUsr: reference.usr) == nil
         }
     }
 

--- a/Tests/AccessibilityTests/AccessibilityProject/Sources/MainTarget/main.swift
+++ b/Tests/AccessibilityTests/AccessibilityProject/Sources/MainTarget/main.swift
@@ -33,6 +33,8 @@ _ = NotRedundantPublicTestableImportClass().testableProperty
 
 ProtocolIndirectlyReferencedCrossModuleByExtensionMemberImpl().somePublicFunc()
 
+PublicProtocolWitnessForExternalProtocolRetainer().retain()
+
 // Properties
 _ = PublicTypeUsedAsPublicPropertyTypeRetainer().retain
 _ = PublicTypeUsedAsPublicPropertyInitializer().retain

--- a/Tests/AccessibilityTests/AccessibilityProject/Sources/TargetA/PublicProtocolWitnessForExternalProtocol.swift
+++ b/Tests/AccessibilityTests/AccessibilityProject/Sources/TargetA/PublicProtocolWitnessForExternalProtocol.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+// The protocol refines the external/stdlib `Identifiable` protocol. The `id` witness is
+// supplied as a default implementation in the extension below. Because `Identifiable` is a
+// public protocol, the witness must remain public, otherwise the compiler emits:
+// "property 'id' must be declared public because it matches a requirement in public protocol
+// 'Identifiable'".
+public protocol PublicProtocolWitnessForExternalProtocol: Identifiable {}
+
+public extension PublicProtocolWitnessForExternalProtocol {
+    var id: String { String(describing: self) }
+}
+
+public enum PublicProtocolWitnessForExternalProtocolEnum: String, PublicProtocolWitnessForExternalProtocol {
+    case first
+    case second
+}
+
+public class PublicProtocolWitnessForExternalProtocolRetainer {
+    public init() {}
+    public func retain() {
+        _ = PublicProtocolWitnessForExternalProtocolEnum.first.id
+    }
+}

--- a/Tests/AccessibilityTests/RedundantPublicAccessibilityTest.swift
+++ b/Tests/AccessibilityTests/RedundantPublicAccessibilityTest.swift
@@ -349,4 +349,14 @@ final class RedundantPublicAccessibilityTest: SPMSourceGraphTestCase {
 
         assertNotRedundantPublicAccessibility(.enum("PublicTypeUsedAsPublicFunctionThrowType"))
     }
+
+    func testPublicProtocolWitnessForExternalProtocol() {
+        index()
+
+        // The `id` witness is supplied in a protocol extension default implementation and satisfies
+        // the requirement of the external public `Identifiable` protocol, so it must remain public.
+        assertNotRedundantPublicAccessibility(.extensionProtocol("PublicProtocolWitnessForExternalProtocol")) {
+            self.assertNotRedundantPublicAccessibility(.varInstance("id"))
+        }
+    }
 }


### PR DESCRIPTION
### Symptom

A `public` member declared in a protocol extension is reported as redundantly public — even when it is the witness for a requirement of an *external* public protocol such as the standard library's `Identifiable`. Removing the `public` modifier, as the report suggests, breaks compilation:

```swift
public protocol StatusRepresentable: RawRepresentable, CaseIterable, Identifiable, Hashable, Sendable
    where RawValue == String {}

// `id` is the witness for Identifiable.id (a public protocol requirement).
public extension StatusRepresentable {
    var id: String { rawValue }   // flagged "redundant public"
}
```

Downgrading the extension from `public` yields: *"property 'id' must be declared public because it matches a requirement in public protocol 'Identifiable'"*.

### Root cause

`RedundantExplicitPublicAccessibilityMarker.validateExtension(_:)` marks a `public extension` as redundantly public whenever the extended type is itself flagged redundant. It does not consider that a member of the extension may be the witness for a requirement of an external public protocol, which obliges the witness to remain at least as accessible as the requirement.

The witness relationship survives in the graph as a related reference on the member whose USR does not resolve to any local declaration (because the protocol — e.g. `Identifiable` — is external). The existing cross-module exemption logic only covers witnesses of *local* protocols, so external-protocol witnesses fall through.

### Fix

Before marking an extension redundantly public, check whether any of its members is the witness for an external protocol requirement: a related reference of a protocol-member-conforming kind, with a matching name, whose USR resolves to no local declaration. If so, the extension is exempt. This is general — it covers any witness for any external public protocol requirement supplied in a protocol-extension default implementation, with no special-casing of `Identifiable` or `id`.

Adds an accessibility test covering a public protocol refining `Identifiable` whose `id` witness is supplied in a default-implementation extension.
