### PR TITLE
Retain SE-0348 result builder methods (buildPartialBlock)

### DIFF
--- a/Sources/SourceGraph/Mutators/ResultBuilderRetainer.swift
+++ b/Sources/SourceGraph/Mutators/ResultBuilderRetainer.swift
@@ -14,6 +14,8 @@ final class ResultBuilderRetainer: SourceGraphMutator {
         "buildBlock(_:)",
         "buildFinalResult(_:)",
         "buildLimitedAvailability(_:)",
+        "buildPartialBlock(first:)",
+        "buildPartialBlock(accumulated:next:)",
     ])
 
     required init(graph: SourceGraph, configuration _: Configuration, swiftVersion _: SwiftVersion) {

--- a/Tests/Fixtures/Sources/RetentionFixtures/testRetainsResultBuilderMethods.swift
+++ b/Tests/Fixtures/Sources/RetentionFixtures/testRetainsResultBuilderMethods.swift
@@ -37,6 +37,14 @@ class FixtureClass130 {
     static func buildLimitedAvailability(_ component: Component) -> Component {
         component
     }
+
+    static func buildPartialBlock(first: Component) -> Component {
+        first
+    }
+
+    static func buildPartialBlock(accumulated: Component, next: Component) -> Component {
+        accumulated + next
+    }
 }
 
 public class FixtureClass130Retainer {

--- a/Tests/PeripheryTests/RetentionTest.swift
+++ b/Tests/PeripheryTests/RetentionTest.swift
@@ -916,6 +916,8 @@ final class RetentionTest: FixtureSourceGraphTestCase {
                 self.assertReferenced(.functionMethodStatic("buildBlock(_:)"))
                 self.assertReferenced(.functionMethodStatic("buildFinalResult(_:)"))
                 self.assertReferenced(.functionMethodStatic("buildLimitedAvailability(_:)"))
+                self.assertReferenced(.functionMethodStatic("buildPartialBlock(first:)"))
+                self.assertReferenced(.functionMethodStatic("buildPartialBlock(accumulated:next:)"))
             }
         }
     }


### PR DESCRIPTION
## Problem

Swift 5.7 introduced [SE-0348](https://github.com/apple/swift-evolution/blob/main/proposals/0348-buildpartialblock.md) which added two new optional static methods to the result builder protocol:

- `buildPartialBlock(first:)`
- `buildPartialBlock(accumulated:next:)`

These are a more expressive alternative to `buildBlock` for incrementally combining components. Because they weren't listed in `ResultBuilderRetainer`, Periphery reported them as unused — a false positive for any result builder that adopts the SE-0348 API.

## Fix

Added both method names to the `resultBuilderMethods` set in `ResultBuilderRetainer.swift`, added implementations to the retention fixture, and added assertions to the existing `testRetainsResultBuilderMethods` test.

## Testing

- Extended `FixtureClass130` in `testRetainsResultBuilderMethods.swift` with both `buildPartialBlock` variants
- Added `assertReferenced` assertions in `RetentionTest.testRetainsResultBuilderMethods()`