### PR TITLE
Write the --write-results file when a scan produces no results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ##### Bug Fixes
 
 - Follow embedded bundle and plugin edges transitively in the generated Bazel scan rule so custom Bazel queries can avoid building incorrectly transitioned targets while still analyzing extension- and plugin-reachable code.
+- The `--write-results` file is now written even when a scan produces no results, instead of being left absent from a prior run.
 
 ## 3.7.4 (2026-04-26)
 

--- a/Sources/Frontend/Commands/ScanCommand.swift
+++ b/Sources/Frontend/Commands/ScanCommand.swift
@@ -295,24 +295,26 @@ struct ScanCommand: ParsableCommand {
         let formatter = outputFormat.formatter.init(configuration: configuration, logger: logger)
         let colored = outputFormat.supportsColoredOutput && logger.isColoredOutputEnabled
 
-        if let output = try formatter.format(filteredResults, colored: colored) {
+        let formattedOutput = try formatter.format(filteredResults, colored: colored)
+
+        if let output = formattedOutput {
             if outputFormat.supportsAuxiliaryOutput {
                 logger.info("", canQuiet: true)
             }
 
             logger.info(output, canQuiet: false)
+        }
 
-            if !filteredResults.isEmpty, let resultsPath = configuration.writeResults {
-                var output = output
-
-                if colored {
-                    // The formatted output contains ANSI escape codes, so we need to re-format
-                    // with coloring disabled.
-                    output = try formatter.format(filteredResults, colored: false) ?? ""
-                }
-
-                try output.write(to: resultsPath.url, atomically: true, encoding: .utf8)
+        if let resultsPath = configuration.writeResults {
+            let output: String = if colored {
+                // The formatted output contains ANSI escape codes, so we need to re-format
+                // with coloring disabled.
+                try formatter.format(filteredResults, colored: false) ?? ""
+            } else {
+                formattedOutput ?? ""
             }
+
+            try output.write(to: resultsPath.url, atomically: true, encoding: .utf8)
         }
 
         logger.endInterval(interval)


### PR DESCRIPTION
`--write-results` only writes its file when the scan produces results, so a clean scan leaves a stale file from a previous run, or none at all.

This also blocks build systems that declare the results file as an expected output, e.g. Bazel fails an action that doesn't create its declared outputs.

The write is hoisted out of the `if let output = try formatter.format(...)` block so it no longer depends on there being console output. That also fixes `--format github-actions`, which returns `nil` for empty results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)