### PR TITLE
Fix/glob literal double asterisk dir

### DIFF
--- a/Sources/Extensions/FilePath+Glob.swift
+++ b/Sources/Extensions/FilePath+Glob.swift
@@ -60,37 +60,51 @@ private final class Glob {
     }
 
     private func expandGlobstar(pattern: String) -> [String] {
-        guard pattern.contains("**") else {
-            return [pattern]
+        expandGlobstar(base: nil, remainder: pattern)
+    }
+
+    /// Expands `**` globstar components in `remainder`, relative to the already-resolved `base`
+    /// directory. `base` is a concrete path and is never re-examined for globstars, so a directory
+    /// literally named `**`or starting with `**` is treated as a literal rather than triggering
+    /// unbounded recursion.
+    private func expandGlobstar(base: URL?, remainder: String) -> [String] {
+        let components = remainder.components(separatedBy: "/")
+
+        guard let globstarIndex = components.firstIndex(of: "**") else {
+            return [resolve(base: base, remainder: remainder)]
         }
 
-        var results = [String]()
-        var parts = pattern.components(separatedBy: "**")
-        let firstPart = parts.removeFirst()
-        var lastPart = parts.joined(separator: "**")
+        let beforeGlobstar = components[..<globstarIndex].joined(separator: "/")
+        let afterGlobstar = components[(globstarIndex + 1)...].joined(separator: "/")
+        let searchRoot = resolve(base: base, remainder: beforeGlobstar)
 
-        let directories: [URL] = if FileManager.default.fileExists(atPath: firstPart) {
-            exploreDirectories(url: URL(fileURLWithPath: firstPart))
+        let directories: [URL] = if FileManager.default.fileExists(atPath: searchRoot) {
+            exploreDirectories(url: URL(fileURLWithPath: searchRoot))
         } else {
             []
         }
 
+        var results = [String]()
+
         // Include the globstar root directory ("dir/") in a pattern like "dir/**" or "dir/**/"
-        if lastPart.isEmpty {
-            results.append(firstPart)
+        if afterGlobstar.isEmpty {
+            results.append(searchRoot)
         }
 
-        if lastPart.isEmpty {
-            lastPart = "*"
-        }
+        let tail = afterGlobstar.isEmpty ? "*" : afterGlobstar
 
         for directory in directories {
-            let partiallyResolvedPattern = directory.appendingPathComponent(lastPart)
-            let standardizedPattern = (partiallyResolvedPattern.relativePath as NSString).standardizingPath
-            results.append(contentsOf: expandGlobstar(pattern: standardizedPattern))
+            // Recursion!
+            results.append(contentsOf: expandGlobstar(base: directory, remainder: tail))
         }
 
         return results
+    }
+
+    private func resolve(base: URL?, remainder: String) -> String {
+        guard let base else { return remainder }
+        let joined = remainder.isEmpty ? base : base.appendingPathComponent(remainder)
+        return FilePath(joined.path).lexicallyNormalized().string
     }
 
     private func exploreDirectories(url: URL) -> [URL] {

--- a/Sources/Extensions/FilePath+Glob.swift
+++ b/Sources/Extensions/FilePath+Glob.swift
@@ -20,9 +20,9 @@ public extension FilePath {
 }
 
 /// Finds files on the file system using Bash v4 style pattern matching.
-///    - A double globstar (**) causes recursive matching in subdirectories.
+///    - A double globstar (`**`) causes recursive matching in subdirectories.
 ///    - Files from the root directory of the globstar are also included.
-///      For example, with the pattern "dir/**/*.ext" the file "dir/file.ext" is also included.
+///      For example, with the pattern `dir/**/*.ext` the file `dir/file.ext` is also included.
 ///    - When the pattern ends with a trailing slash, only directories are matched.
 private final class Glob {
     private let excludedDirectories: [String]

--- a/Tests/PeripheryTests/Extensions/FilePathGlobTest.swift
+++ b/Tests/PeripheryTests/Extensions/FilePathGlobTest.swift
@@ -2,14 +2,26 @@ import SystemPackage
 import XCTest
 
 final class FilePathGlobTest: XCTestCase {
-    private let files = ["foo", "bar", "baz", "dir1/file1.ext", "dir1/dir2/dir3/file2.ext"]
+    private let files = [
+        "foo",
+        "bar",
+        "baz",
+        "dir1/file1.ext",
+        "dir1/dir2/dir3/file2.ext",
+        "** ExampleFolder/file3.ext", // A directory name starting with "**" is a literal, not a globstar.
+        "**/file4.ext", // A directory name that is exactly "**".
+        "mid**dle/file5.ext", // "**" in the middle of a name must not be read as a globstar.
+    ]
     private let baseDir = FilePath.current.appending("tmp/FilePathGlobTest").string
     private let fileManager = FileManager.default
 
     override func setUpWithError() throws {
         super.setUp()
-        try fileManager.createDirectory(atPath: "\(baseDir)/dir1/dir2/dir3/", withIntermediateDirectories: true, attributes: nil)
-        files.forEach { fileManager.createFile(atPath: "\(baseDir)/\($0)", contents: nil, attributes: nil) }
+        for file in files {
+            let path = "\(baseDir)/\(file)"
+            try fileManager.createDirectory(atPath: (path as NSString).deletingLastPathComponent, withIntermediateDirectories: true, attributes: nil)
+            fileManager.createFile(atPath: path, contents: nil, attributes: nil)
+        }
     }
 
     override func tearDownWithError() throws {
@@ -41,6 +53,10 @@ final class FilePathGlobTest: XCTestCase {
         let paths = FilePath.glob(pattern).sorted()
         XCTAssertPathsEqual(paths, [
             baseDir,
+            "\(baseDir)/**",
+            "\(baseDir)/** ExampleFolder",
+            "\(baseDir)/** ExampleFolder/file3.ext",
+            "\(baseDir)/**/file4.ext",
             "\(baseDir)/bar",
             "\(baseDir)/baz",
             "\(baseDir)/dir1",
@@ -49,6 +65,8 @@ final class FilePathGlobTest: XCTestCase {
             "\(baseDir)/dir1/dir2/dir3/file2.ext",
             "\(baseDir)/dir1/file1.ext",
             "\(baseDir)/foo",
+            "\(baseDir)/mid**dle",
+            "\(baseDir)/mid**dle/file5.ext",
         ])
     }
 
@@ -58,9 +76,12 @@ final class FilePathGlobTest: XCTestCase {
         let paths = FilePath.glob(pattern).sorted()
         XCTAssertPathsEqual(paths, [
             baseDir,
+            "\(baseDir)/**",
+            "\(baseDir)/** ExampleFolder",
             "\(baseDir)/dir1",
             "\(baseDir)/dir1/dir2",
             "\(baseDir)/dir1/dir2/dir3",
+            "\(baseDir)/mid**dle",
         ])
     }
 
@@ -69,6 +90,10 @@ final class FilePathGlobTest: XCTestCase {
         let pattern = "\(baseDir)/**/*"
         let paths = FilePath.glob(pattern).sorted()
         XCTAssertPathsEqual(paths, [
+            "\(baseDir)/**",
+            "\(baseDir)/** ExampleFolder",
+            "\(baseDir)/** ExampleFolder/file3.ext",
+            "\(baseDir)/**/file4.ext",
             "\(baseDir)/bar",
             "\(baseDir)/baz",
             "\(baseDir)/dir1",
@@ -77,6 +102,8 @@ final class FilePathGlobTest: XCTestCase {
             "\(baseDir)/dir1/dir2/dir3/file2.ext",
             "\(baseDir)/dir1/file1.ext",
             "\(baseDir)/foo",
+            "\(baseDir)/mid**dle",
+            "\(baseDir)/mid**dle/file5.ext",
         ])
     }
 
@@ -94,8 +121,11 @@ final class FilePathGlobTest: XCTestCase {
             let pattern = "**/*.ext"
             let paths = FilePath.glob(pattern).sorted()
             XCTAssertPathsEqual(paths, [
+                "\(baseDir)/** ExampleFolder/file3.ext",
+                "\(baseDir)/**/file4.ext",
                 "\(baseDir)/dir1/dir2/dir3/file2.ext",
                 "\(baseDir)/dir1/file1.ext",
+                "\(baseDir)/mid**dle/file5.ext",
             ])
         }
     }
@@ -113,8 +143,11 @@ final class FilePathGlobTest: XCTestCase {
             let pattern = "../../**/*.ext"
             let paths = FilePath.glob(pattern).sorted()
             XCTAssertPathsEqual(paths, [
+                "\(baseDir)/** ExampleFolder/file3.ext",
+                "\(baseDir)/**/file4.ext",
                 "\(baseDir)/dir1/dir2/dir3/file2.ext",
                 "\(baseDir)/dir1/file1.ext",
+                "\(baseDir)/mid**dle/file5.ext",
             ])
         }
     }

--- a/Tests/PeripheryTests/Extensions/FilePathGlobTest.swift
+++ b/Tests/PeripheryTests/Extensions/FilePathGlobTest.swift
@@ -11,6 +11,9 @@ final class FilePathGlobTest: XCTestCase {
         "** ExampleFolder/file3.ext", // A directory name starting with "**" is a literal, not a globstar.
         "**/file4.ext", // A directory name that is exactly "**".
         "mid**dle/file5.ext", // "**" in the middle of a name must not be read as a globstar.
+        "dir1/** ExampleFile.ext", // A file name starting with "**".
+        "dir1/fi**le.ext", // "**" in the middle of a file name.
+        "dir1/**", // A file name that is exactly "**".
     ]
     private let baseDir = FilePath.current.appending("tmp/FilePathGlobTest").string
     private let fileManager = FileManager.default
@@ -60,9 +63,12 @@ final class FilePathGlobTest: XCTestCase {
             "\(baseDir)/bar",
             "\(baseDir)/baz",
             "\(baseDir)/dir1",
+            "\(baseDir)/dir1/**",
+            "\(baseDir)/dir1/** ExampleFile.ext",
             "\(baseDir)/dir1/dir2",
             "\(baseDir)/dir1/dir2/dir3",
             "\(baseDir)/dir1/dir2/dir3/file2.ext",
+            "\(baseDir)/dir1/fi**le.ext",
             "\(baseDir)/dir1/file1.ext",
             "\(baseDir)/foo",
             "\(baseDir)/mid**dle",
@@ -97,9 +103,12 @@ final class FilePathGlobTest: XCTestCase {
             "\(baseDir)/bar",
             "\(baseDir)/baz",
             "\(baseDir)/dir1",
+            "\(baseDir)/dir1/**",
+            "\(baseDir)/dir1/** ExampleFile.ext",
             "\(baseDir)/dir1/dir2",
             "\(baseDir)/dir1/dir2/dir3",
             "\(baseDir)/dir1/dir2/dir3/file2.ext",
+            "\(baseDir)/dir1/fi**le.ext",
             "\(baseDir)/dir1/file1.ext",
             "\(baseDir)/foo",
             "\(baseDir)/mid**dle",
@@ -123,7 +132,9 @@ final class FilePathGlobTest: XCTestCase {
             XCTAssertPathsEqual(paths, [
                 "\(baseDir)/** ExampleFolder/file3.ext",
                 "\(baseDir)/**/file4.ext",
+                "\(baseDir)/dir1/** ExampleFile.ext",
                 "\(baseDir)/dir1/dir2/dir3/file2.ext",
+                "\(baseDir)/dir1/fi**le.ext",
                 "\(baseDir)/dir1/file1.ext",
                 "\(baseDir)/mid**dle/file5.ext",
             ])
@@ -145,7 +156,9 @@ final class FilePathGlobTest: XCTestCase {
             XCTAssertPathsEqual(paths, [
                 "\(baseDir)/** ExampleFolder/file3.ext",
                 "\(baseDir)/**/file4.ext",
+                "\(baseDir)/dir1/** ExampleFile.ext",
                 "\(baseDir)/dir1/dir2/dir3/file2.ext",
+                "\(baseDir)/dir1/fi**le.ext",
                 "\(baseDir)/dir1/file1.ext",
                 "\(baseDir)/mid**dle/file5.ext",
             ])


### PR DESCRIPTION
Fixes #1144

Added some tests for folders (and files, for good measure) that start with or contain `**`. Modified the `expandGlobstar` function to make sure it does not re-expand directories starting with `**` that it finds when expanding a `**` glob. Machine-assisted, so please review accordingly. I won't be insulted if you want to fix this your own way or propose substantial changes.