### PR TITLE
`xcodebuild -list`: honor --clean-build and control the derived data location

### DIFF
--- a/Sources/ProjectDrivers/XcodeProjectDriver.swift
+++ b/Sources/ProjectDrivers/XcodeProjectDriver.swift
@@ -60,6 +60,9 @@
                 schemes = Set(configuration.schemes)
             } else {
                 // Ensure schemes exist within the project
+                if configuration.cleanBuild {
+                    try xcodebuild.removeDerivedData(for: project, allSchemes: [])
+                }
                 schemes = try project.schemes(
                     additionalArguments: configuration.xcodeListArguments
                 ).filter { configuration.schemes.contains($0) }

--- a/Sources/XcodeSupport/Xcodebuild.swift
+++ b/Sources/XcodeSupport/Xcodebuild.swift
@@ -79,10 +79,12 @@ public final class Xcodebuild {
     }
 
     func schemes(type: String, path: String, additionalArguments: [String]) throws -> Set<String> {
+        let derivedDataPath = try derivedDataPath(projectName: path, schemes: []).string
         let args = [
             "-\(type)", "\"\(path.withEscapedQuotes)\"",
             "-list",
             "-json",
+            "-IDECustomDerivedDataLocation", "'\(derivedDataPath)'",
         ]
 
         let quotedArguments = quote(arguments: additionalArguments)
@@ -120,15 +122,17 @@ public final class Xcodebuild {
     }
 
     private func derivedDataPath(for project: XcodeProjectlike, schemes: [String]) throws -> FilePath {
+        try derivedDataPath(projectName: project.name, schemes: schemes)
+    }
+    
+    private func derivedDataPath(projectName: String, schemes: [String]) throws -> FilePath {
         // Given a project with two schemes: A and B, a scenario can arise where the index store contains conflicting
         // data. If scheme A is built, then the source file modified and then scheme B built, the index store will
         // contain two records for that source file. One reflects the state of the file when scheme A was built, and the
         // other when B was built. We must therefore key the DerivedData path with the full list of schemes being built.
-
         let xcodeVersionHash = try version().djb2Hex
-        let projectHash = project.name.djb2Hex
+        let projectHash = projectName.djb2Hex
         let schemesHash = Array(schemes).joined().djb2Hex
-
         return try Constants.cachePath().appending("DerivedData-\(xcodeVersionHash)-\(projectHash)-\(schemesHash)")
     }
 

--- a/Sources/XcodeSupport/Xcodebuild.swift
+++ b/Sources/XcodeSupport/Xcodebuild.swift
@@ -79,12 +79,19 @@ public final class Xcodebuild {
     }
 
     func schemes(type: String, path: String, additionalArguments: [String]) throws -> Set<String> {
-        let derivedDataPath = try derivedDataPath(projectName: path, schemes: []).string
         let args = [
             "-\(type)", "\"\(path.withEscapedQuotes)\"",
             "-list",
             "-json",
-            "-IDECustomDerivedDataLocation", "'\(derivedDataPath)'",
+            // since `xcodebuild -list` performs package resolution (meaning that it needs a DerivedData folder),
+            // but doesn't support `-derivedDataPath`, we instead use `-IDECustomDerivedDataLocation=<path>`.
+            // the difference between the two is that the former points to the specific folder xcodebuild will use
+            // for its build output, whereas the latter points to the parent folder.
+            // i.e., `-IDECustomDerivedDataLocation=<path>` is effectively identical to
+            // `-derivedDataPath <path>/<xcode-default-hashed-folder-name>`.
+            // this is not a problem, since we still can scope the folders on a per-project
+            // and per-xcode-version level; the actual contents just happen to be one level deeper.
+            "-IDECustomDerivedDataLocation='\(try derivedDataPath(projectName: path, schemes: []).string)'",
         ]
 
         let quotedArguments = quote(arguments: additionalArguments)

--- a/Sources/XcodeSupport/Xcodebuild.swift
+++ b/Sources/XcodeSupport/Xcodebuild.swift
@@ -55,8 +55,10 @@ public final class Xcodebuild {
         return try shell.exec(xcodebuild)
     }
 
+    /// removes the DerivedData folder used to build the specified schemes
     public func removeDerivedData(for project: XcodeProjectlike, allSchemes: [String]) throws {
-        try shell.exec(["rm", "-rf", derivedDataPath(for: project, schemes: allSchemes).string])
+        let path = try derivedDataPath(for: project, schemes: allSchemes).string
+        try self.shell.exec(["rm", "-rf", path])
     }
 
     public func indexStorePath(project: XcodeProjectlike, schemes: [String]) throws -> FilePath {
@@ -91,7 +93,7 @@ public final class Xcodebuild {
             // `-derivedDataPath <path>/<xcode-default-hashed-folder-name>`.
             // this is not a problem, since we still can scope the folders on a per-project
             // and per-xcode-version level; the actual contents just happen to be one level deeper.
-            "-IDECustomDerivedDataLocation='\(try derivedDataPath(projectName: path, schemes: []).string)'",
+            "-IDECustomDerivedDataLocation='\(try derivedDataPath(projectIdentifier: path, schemes: []).string)'",
         ]
 
         let quotedArguments = quote(arguments: additionalArguments)
@@ -129,18 +131,24 @@ public final class Xcodebuild {
     }
 
     private func derivedDataPath(for project: XcodeProjectlike, schemes: [String]) throws -> FilePath {
-        try derivedDataPath(projectName: project.name, schemes: schemes)
+        try derivedDataPath(
+            projectIdentifier: project.path.lexicallyNormalized().string,
+            schemes: schemes
+        )
     }
-    
-    private func derivedDataPath(projectName: String, schemes: [String]) throws -> FilePath {
+
+    private func derivedDataPath(projectIdentifier: String, schemes: [String]) throws -> FilePath {
         // Given a project with two schemes: A and B, a scenario can arise where the index store contains conflicting
         // data. If scheme A is built, then the source file modified and then scheme B built, the index store will
         // contain two records for that source file. One reflects the state of the file when scheme A was built, and the
         // other when B was built. We must therefore key the DerivedData path with the full list of schemes being built.
-        let xcodeVersionHash = try version().djb2Hex
-        let projectHash = projectName.djb2Hex
-        let schemesHash = Array(schemes).joined().djb2Hex
-        return try Constants.cachePath().appending("DerivedData-\(xcodeVersionHash)-\(projectHash)-\(schemesHash)")
+        var name = "DerivedData"
+        name += "-\(try version().djb2Hex)"
+        name += "-\(projectIdentifier.djb2Hex)"
+        if !schemes.isEmpty {
+            name += "-\(schemes.joined().djb2Hex)"
+        }
+        return try Constants.cachePath().appending(name)
     }
 
     private func quote(arguments: [String]) -> [String] {


### PR DESCRIPTION
see https://github.com/peripheryapp/periphery/issues/1146 for more details

this PR makes the following 2 changes:
- periphery's internal `xcodebuild -list` invocation no longer runs in the context of the global `~/Library/Developer/Xcode/DerivedData` folder and instead uses a custom derived data folder located within `~/Library/Caches/com.github.peripheryapp` (alongside the other derived data folders used when running `xcodebuild ... build`)
- periphery now honors the `--clean-build` flag when resolving an xcode project's schemes, and clears the derived data folder before running `xcodebuild -list`